### PR TITLE
V1.2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.xlsx
 *.xlsm
+*.csv
 .vscode
 __pycache__
 *.log*

--- a/app.py
+++ b/app.py
@@ -51,7 +51,8 @@ logging.basicConfig(
 )
 # Log to console and file
 CONSOLE = logging.StreamHandler()
-FORMATTER = logging.Formatter('%(asctime)s: %(levelname)-8s %(message)s')
+CONSOLE.setLevel(logging.INFO)
+FORMATTER = logging.Formatter('%(asctime)s %(levelname)s %(message)s')
 CONSOLE.setFormatter(FORMATTER)
 logging.getLogger('').addHandler(CONSOLE)
 

--- a/app.py
+++ b/app.py
@@ -175,7 +175,8 @@ class ProcessWorkbook:
             return True
         return False
 
-    def serial_is_special(self, serial):
+    @staticmethod
+    def serial_is_special(serial):
         """
             If a provided `serial` is determined to be
             special for any reason, this method will

--- a/app.py
+++ b/app.py
@@ -120,7 +120,7 @@ class ProcessWorkbook:
 
         for row in self.failed_records:
             logging.info(
-                'Row that failed Record Creation: %s | %s | %s | %s | %s' % (
+                'Row that failed Record Creation: %s | %s | %s | %s | %s', (
                     row[0].value,
                     row[1].value,
                     row[3].value,

--- a/app.py
+++ b/app.py
@@ -259,6 +259,7 @@ class ProcessWorkbook:
                     self.records.append(record)
 
             if not record:
+                logging.error('Failed to create a Record from Row: %s', (row))
                 self.failed_records.append(row)
 
             self.rows_processed += 1

--- a/app.py
+++ b/app.py
@@ -455,9 +455,19 @@ class ProcessWorkbook:
         return self
 
     def remove_ignored_records(self):
-        logging.info('Removing ignored records')
+        """
+            Populates `self.records_to_upload` with
+            any record that is not also a part of the
+            `self.serials_to_ignore` list, counts the
+            serials that were ignored, and writes those
+            rows to an ignore csv
+        """
+        logging.info('Removing Ignored Serials from Records')
 
-        self.records_to_upload = [x for x in self.records if x.serial not in self.serials_to_ignore]
+        self.records_to_upload = [
+            x for x in self.records
+            if x.serial not in self.serials_to_ignore
+        ]
 
         for record in self.records:
             if record.serial in self.serials_to_ignore:

--- a/app.py
+++ b/app.py
@@ -355,9 +355,7 @@ class ProcessWorkbook:
             [
                 ('catalog', '=', ASSET_CATALOG_ID),
                 ('make', '=', self.get_id_from_model(record.model)),
-                '|',
                 ('serial', '=ilike', record.serial),
-                ('tag', '=ilike', record.asset_tag),
             ]
         )
         if len(result) > 0:

--- a/app.py
+++ b/app.py
@@ -350,8 +350,7 @@ class ProcessWorkbook:
             a line item matching the provided `record`.
 
             Determines if a line is the same if either the
-            serial number or the asset tag was previously
-            recorded, but only if the tag is not empty/generic.
+            serial number was previously recorded.
 
             Returns True if there is an existing record in Odoo,
             False otherwise.

--- a/app.py
+++ b/app.py
@@ -32,14 +32,8 @@ LAST_COL = 6 # The last column to read from in each row
 
 # Items in this list will not be checked for pre-existing records
 # and new records will always be created (at the risk of duplicate data)
+SERIALS_TO_IGNORE = []
 
-
-
-
-
-# Items in this list will not be imported,
-# but rather added to a discrepancy csv file
-SPECIAL_SERIALS = []
 SPECIAL_CSV = '<your special csv>-%s.csv' % (time.time())
 SPECIAL_FIELDS = ['serial', 'asset_tag', 'make', 'model', 'device_type', 'children']
 

--- a/app.py
+++ b/app.py
@@ -442,7 +442,7 @@ class ProcessWorkbook:
         logging.info('Creating Line items for accepted records in Odoo')
         for record in self.records:
 
-            # Don't create lines for special serials
+            # Don't create lines for serials to ignore
             if record.serial in self.serials_to_ignore:
                 self.records_ignored += 1
                 logging.warning(

--- a/app.py
+++ b/app.py
@@ -44,7 +44,6 @@ SERIALS_TO_IGNORE = os.environ.get('serials_to_ignore').strip().split('\n')
 
 FILENAME_TIME = '%s' % (time.time())
 SPECIAL_CSV = '%s.csv' % (FILENAME_TIME)
-SPECIAL_FIELDS = ['serial', 'asset_tag', 'make', 'model', 'device_type', 'children']
 
 # Logging
 logging.basicConfig(
@@ -130,7 +129,10 @@ class ProcessWorkbook:
         self.special_csv_file = open(SPECIAL_CSV, 'w')
         self.special_csv = csv.DictWriter(
             self.special_csv_file,
-            fieldnames=SPECIAL_FIELDS,
+            fieldnames=[
+                'serial', 'asset_tag', 'make',
+                'model', 'device_type', 'children'
+            ],
             dialect=csv.excel
         )
         self.special_csv.writeheader()

--- a/app.py
+++ b/app.py
@@ -119,7 +119,7 @@ class ProcessWorkbook:
         logging.info('Prevented %d Records from being uploaded', (self.records_ignored))
 
         for row in self.failed_records:
-            # pylint: disable=logging-no-lazy
+            # pylint: disable=logging-not-lazy
             logging.info(
                 'Row that failed Record Creation: %s | %s | %s | %s | %s' % (
                     row[0].value,

--- a/app.py
+++ b/app.py
@@ -20,7 +20,6 @@ import time
 import json
 import logging
 import itertools
-from pprint import pprint
 
 from openpyxl import load_workbook
 from api import API
@@ -314,11 +313,10 @@ class ProcessWorkbook:
 
     def show_records(self):
         """
-            Pretty Prints a JSON string for all
-            of the records that are stored
+            Logs all of the records stored, in JSON format
         """
         # pylint: disable=unnecessary-comprehension
-        logging.debug(pprint([record for record in self.records]))
+        logging.debug([record for record in self.records])
 
     def get_odoo_model_ids(self):
         """

--- a/app.py
+++ b/app.py
@@ -260,7 +260,6 @@ class ProcessWorkbook:
                     self.records.append(record)
 
             if not record:
-                logging.error('Failed to create a Record from Row: %s', (row))
                 self.failed_records.append(row)
 
             self.rows_processed += 1

--- a/app.py
+++ b/app.py
@@ -143,6 +143,8 @@ class ProcessWorkbook:
         self.serials_to_ignore = [None, '', 'N/A']
         self.serials_to_ignore.extend(SERIALS_TO_IGNORE)
 
+        self.rows_processed = 0
+
         logging.info('Initialized ProcessWorkbook')
 
     def __del__(self):
@@ -151,6 +153,7 @@ class ProcessWorkbook:
         """
         self.special_csv_file.close()
 
+        logging.info('Processed %d rows', (self.rows_processed + 1))
         logging.info('ProcessWorkbook Finished')
 
     def get_id_from_model(self, model):
@@ -278,6 +281,8 @@ class ProcessWorkbook:
                 record = self.create_record_from_row(row, False)
                 if record:
                     self.records.append(record)
+
+            self.rows_processed += 1
 
         return self
 

--- a/app.py
+++ b/app.py
@@ -17,11 +17,11 @@
 import os
 import csv
 import time
-import json
 import logging
 import itertools
 
 from openpyxl import load_workbook
+from record import Record
 from api import API
 
 # Odoo Stuff
@@ -58,61 +58,6 @@ CONSOLE.setLevel(logging.INFO)
 FORMATTER = logging.Formatter('%(asctime)s %(levelname)s %(message)s')
 CONSOLE.setFormatter(FORMATTER)
 logging.getLogger('').addHandler(CONSOLE)
-
-class Record:
-    """
-        Stores information about the line items to import.
-
-        All fields but one are expected to be of type `str`,
-        and this class will enforce that when an instance is created.
-        The only field that is not expected to be a string is
-        the `children` field, which should be a list containing
-        one or more Record objects, or None
-    """
-
-    def __init__(self, **kwargs):
-        self.serial = str(kwargs.get('serial'))
-        self.asset_tag = str(kwargs.get('asset_tag'))
-        self.make = str(kwargs.get('make'))
-        self.model = str(kwargs.get('model'))
-        self.device_type = str(kwargs.get('device_type'))
-
-        self.children = kwargs.get('children', list())
-
-        # Special case for serial numbers recorded as dell links
-        if 'dell.com' in self.serial:
-            # We assume that there are no '/' characters in the serial,
-            # and that the serial is the very last thing in the link.
-            # For dell, this is fine, as they are sturctured like:
-            # https://qrl.dell.com/H6FND42
-            self.serial = self.serial.split('/')[-1]
-
-    def __str__(self):
-        """
-            Returns the serial number of this Record instance
-        """
-        return self.serial
-
-    def __repr__(self):
-        """
-            Used when iterating over a list of Record objects
-
-            Returns a JSON serialized string that
-            represents this Record. Children will be
-            represented as a list of dictionaries or
-            `null`
-        """
-        return json.dumps({
-            'serial': self.serial,
-            'asset_tag': self.asset_tag,
-            'make': self.make,
-            'model': self.model,
-            'device_type': self.device_type,
-            'children': [
-                child.__dict__ for child in self.children
-                if child is not None
-            ] if self.children is not None else None,
-        })
 
 class ProcessWorkbook:
     """

--- a/app.py
+++ b/app.py
@@ -163,9 +163,10 @@ class ProcessWorkbook:
         """
         if records is None:
             records = self.records
+        if serial in self.serials_to_ignore:
+            return False
         if serial in [record.serial for record in records if record.serial]:
-            if serial not in self.serials_to_ignore:
-                return True
+            return True
         return False
 
     def create_record_from_row(self, row, parent=True, search_model=True):

--- a/app.py
+++ b/app.py
@@ -43,7 +43,7 @@ LAST_COL = int(os.environ.get('last_col', 6))
 SERIALS_TO_IGNORE = os.environ.get('serials_to_ignore').strip().split('\n')
 
 FILENAME_TIME = '%s' % (time.time())
-SPECIAL_CSV = '%s.csv' % (FILENAME_TIME)
+IGNORE_CSV = '%s.csv' % (FILENAME_TIME)
 
 # Logging
 logging.basicConfig(
@@ -71,16 +71,16 @@ class ProcessWorkbook:
         self.workbook = load_workbook(filename=SPREADSHEET, data_only=True)[SHEET]
 
         # Special Serials
-        self.special_csv_file = open(SPECIAL_CSV, 'w')
-        self.special_csv = csv.DictWriter(
-            self.special_csv_file,
+        self.ignore_csv_file = open(IGNORE_CSV, 'w')
+        self.ignore_csv = csv.DictWriter(
+            self.ignore_csv_file,
             fieldnames=[
                 'serial', 'asset_tag', 'make',
                 'model', 'device_type', 'children'
             ],
             dialect=csv.excel
         )
-        self.special_csv.writeheader()
+        self.ignore_csv.writeheader()
 
         # Failed records are rows that for one reason or another didn't generate a Record object
         self.failed_records = list()
@@ -110,7 +110,7 @@ class ProcessWorkbook:
         """
             Automatically closes file handlers when destructed normally
         """
-        self.special_csv_file.close()
+        self.ignore_csv_file.close()
 
         logging.info('Processed %d rows', (self.rows_processed))
         logging.info('Created %d Records', (len(self.records)))
@@ -449,7 +449,7 @@ class ProcessWorkbook:
                 logging.warning(
                     '"%s" is special, skipping import and saving to special list', (record.serial)
                 )
-                self.special_csv.writerow({
+                self.ignore_csv.writerow({
                     'serial': record.serial,
                     'asset_tag': record.asset_tag,
                     'make': record.make,

--- a/app.py
+++ b/app.py
@@ -358,7 +358,6 @@ class ProcessWorkbook:
                 '|',
                 ('serial', '=ilike', record.serial),
                 ('tag', '=ilike', record.asset_tag),
-                ('tag', 'not in', [False, '', 'N/A']),
             ]
         )
         if len(result) > 0:

--- a/app.py
+++ b/app.py
@@ -59,6 +59,12 @@ FORMATTER = logging.Formatter('%(asctime)s %(levelname)s %(message)s')
 CONSOLE.setFormatter(FORMATTER)
 logging.getLogger('').addHandler(CONSOLE)
 
+# Sanity Checks
+if ASSET_CATALOG_ID <= 0:
+    logging.warning('Zero or negative asset catalog. Records will not get uploaded to it')
+if DATA_DESTRUCTION_ID <= 0:
+    logging.warning('Zero or negative data destruction. Records will not get uploaded to it')
+
 class ProcessWorkbook:
     """
         Provides a mechanism for extracting the content

--- a/app.py
+++ b/app.py
@@ -110,7 +110,10 @@ class Record:
             'make': self.make,
             'model': self.model,
             'device_type': self.device_type,
-            'children': [child.__dict__ for child in self.children if child is not None],
+            'children': [
+                child.__dict__ for child in self.children
+                if child is not None
+            ] if self.children is not None else None,
         })
 
 class ProcessWorkbook:
@@ -162,11 +165,11 @@ class ProcessWorkbook:
         """
         self.special_csv_file.close()
 
-        logging.info('Processed %d rows', (self.rows_processed + 1))
-        logging.info('Created %d Records', (self.records_created + 1))
-        logging.info('Uploaded %d Sorting Assets', (self.sorting_records_uploaded + 1))
-        logging.info('Uploaded %d Data Destruction Assets', (self.data_records_uploaded + 1))
-        logging.info('Ignored %d Records', (self.records_ignored + 1))
+        logging.info('Processed %d rows', (self.rows_processed))
+        logging.info('Created %d Records', (self.records_created))
+        logging.info('Uploaded %d Sorting Assets', (self.sorting_records_uploaded))
+        logging.info('Uploaded %d Data Destruction Assets', (self.data_records_uploaded))
+        logging.info('Ignored %d Records', (self.records_ignored))
         logging.info('ProcessWorkbook Finished')
 
     def get_id_from_model(self, model):
@@ -315,7 +318,7 @@ class ProcessWorkbook:
             of the records that are stored
         """
         # pylint: disable=unnecessary-comprehension
-        logging.info(pprint([record for record in self.records]))
+        logging.debug(pprint([record for record in self.records]))
 
     def get_odoo_model_ids(self):
         """
@@ -510,6 +513,7 @@ class ProcessWorkbook:
             Runs everything in the order that is required
         """
         self.build_record_list()
+        self.show_records()
         self.get_odoo_model_ids()
         self.create_missing_model_ids()
         self.create_line_items()

--- a/app.py
+++ b/app.py
@@ -117,7 +117,18 @@ class ProcessWorkbook:
         logging.info('Uploaded %d Sorting Assets', (self.sorting_records_uploaded))
         logging.info('Uploaded %d Data Destruction Assets', (self.data_records_uploaded))
         logging.info('Prevented %d Records from being uploaded', (self.records_ignored))
-        logging.info('Rows that failed Record Creation: %s', (self.failed_records))
+
+        for row in self.failed_records:
+            logging.info(
+                'Row that failed Record Creation: %s | %s | %s | %s | %s' % (
+                    row[0].value,
+                    row[1].value,
+                    row[3].value,
+                    row[4].value,
+                    row[5].value
+                )
+            )
+
         logging.info('ProcessWorkbook Finished')
 
     def get_id_from_model(self, model):

--- a/app.py
+++ b/app.py
@@ -49,6 +49,11 @@ logging.basicConfig(
     format='%(asctime)s - %(levelname)s - %(message)s',
     datefmt='%m/%d/%Y %I:%M:%S %p'
 )
+# Log to console and file
+CONSOLE = logging.StreamHandler()
+FORMATTER = logging.Formatter('%(asctime)s: %(levelname)-8s %(message)s')
+CONSOLE.setFormatter(FORMATTER)
+logging.getLogger('').addHandler(CONSOLE)
 
 class Record:
     """

--- a/app.py
+++ b/app.py
@@ -119,8 +119,9 @@ class ProcessWorkbook:
         logging.info('Prevented %d Records from being uploaded', (self.records_ignored))
 
         for row in self.failed_records:
+            # pylint: disable=logging-no-lazy
             logging.info(
-                'Row that failed Record Creation: %s | %s | %s | %s | %s', (
+                'Row that failed Record Creation: %s | %s | %s | %s | %s' % (
                     row[0].value,
                     row[1].value,
                     row[3].value,

--- a/app.py
+++ b/app.py
@@ -32,6 +32,8 @@ LAST_COL = 6 # The last column to read from in each row
 
 # Items in this list will not be checked for pre-existing records
 # and new records will always be created (at the risk of duplicate data)
+SERIALS_TO_IGNORE = []
+
 # Items in this list will not be imported,
 # but rather added to a discrepancy csv file
 SPECIAL_SERIALS = []

--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Saving of "Serials to Ignore" to a CSV file. This is used to select lines that shouldn't be imported, but do need to be looked at carefully
+- The number of rows being processed is kept track of and reported at the end of the program
 
 ### Changed
 

--- a/changelog.md
+++ b/changelog.md
@@ -12,13 +12,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Saving of "Serials to Ignore" to a CSV file. This is used to select lines that shouldn't be imported, but do need to be looked at carefully
 - The number of rows being processed is kept track of and reported at the end of the program
 - CSV files generated as a result of this program are now ignored in git
+- We now keep track of the number of each type of record uploaded
+- We now track instances of failed records and see the data. Normally when a record fails to be created, it is due to being a duplicate.
 
 ### Changed
 
 - Asset lines are now checked to see if they exist in Odoo before blindly creating new records (Asset Catalog only. This is not currently on the data destruction)
 - Record objects are now able to be duplicated for cases of "Serials to Ignore" (Multiple Records with the same "Serial Number")
-- The Print statements have been replaced with native logging
+- The Print statements have been replaced with native logging, which output to STDOUT and a file
 - Configuration of this program has been moved to `run.sh`. You should not need to alter `app.py` going forward.
+- The Record class has been broken out into its own file, to help with readability
 
 ## [1.1.1] - 2020-05-27
 

--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.0] - 2020-05-28
+
 ### Added
 
 - Saving of "Serials to Ignore" to a CSV file. This is used to select lines that shouldn't be imported, but do need to be looked at carefully

--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Saving of "Special Serials" to a CSV file. This is used to select lines that shouldn't be imported, but do need to be looked at carefully
+
+### Changed
+
+- Asset lines are now checked to see if they exist in Odoo before blindly creating new records (Asset Catalog only. This is not currently on the data destruction)
+
 ## [1.1.1] - 2020-04-06
 
 ### Added

--- a/changelog.md
+++ b/changelog.md
@@ -9,11 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Saving of "Special Serials" to a CSV file. This is used to select lines that shouldn't be imported, but do need to be looked at carefully
+- Saving of "Serials to Ignore" to a CSV file. This is used to select lines that shouldn't be imported, but do need to be looked at carefully
 
 ### Changed
 
 - Asset lines are now checked to see if they exist in Odoo before blindly creating new records (Asset Catalog only. This is not currently on the data destruction)
+- Record objects are now able to be duplicated for cases of "Serials to Ignore" (Multiple Records with the same "Serial Number")
 
 ## [1.1.1] - 2020-05-27
 

--- a/changelog.md
+++ b/changelog.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Asset lines are now checked to see if they exist in Odoo before blindly creating new records (Asset Catalog only. This is not currently on the data destruction)
 
-## [1.1.1] - 2020-04-06
+## [1.1.1] - 2020-05-27
 
 ### Added
 

--- a/changelog.md
+++ b/changelog.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Asset lines are now checked to see if they exist in Odoo before blindly creating new records (Asset Catalog only. This is not currently on the data destruction)
 - Record objects are now able to be duplicated for cases of "Serials to Ignore" (Multiple Records with the same "Serial Number")
+- The Print statements have been replaced with native logging
 
 ## [1.1.1] - 2020-05-27
 

--- a/changelog.md
+++ b/changelog.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Saving of "Serials to Ignore" to a CSV file. This is used to select lines that shouldn't be imported, but do need to be looked at carefully
 - The number of rows being processed is kept track of and reported at the end of the program
+- CSV files generated as a result of this program are now ignored in git
 
 ### Changed
 

--- a/changelog.md
+++ b/changelog.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Asset lines are now checked to see if they exist in Odoo before blindly creating new records (Asset Catalog only. This is not currently on the data destruction)
 - Record objects are now able to be duplicated for cases of "Serials to Ignore" (Multiple Records with the same "Serial Number")
 - The Print statements have been replaced with native logging
+- Configuration of this program has been moved to `run.sh`. You should not need to alter `app.py` going forward.
 
 ## [1.1.1] - 2020-05-27
 

--- a/docker-lint.sh
+++ b/docker-lint.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
-# Part of erp-inventory
-# License: Odoo Proprietary V1
-# Author: David Todd (dtodd@oceantech.com)
+# Part of XLSX to Odoo import
+# Copyright 2020 David Todd <dtodd@oceantech.com>
+# License: MIT License, refer to `license.md` for more information
 
 # This is a simple script that will build and run the linter docker container
 # Expects a user that has the `docker` group or is `root` (NOTE: The docker group grants privileges equivalent to the root user)

--- a/readme.md
+++ b/readme.md
@@ -14,7 +14,7 @@ The types of records that are created are:
 
 ## Version
 
-The current version is 1.1.1. Please check changelog.md for more information.
+The current version is 1.2.0. Please check changelog.md for more information.
 
 ## Usage
 

--- a/readme.md
+++ b/readme.md
@@ -24,10 +24,13 @@ The ideas within this application should be able to be adapted towards processin
 1. Clone this repo
 1. Ensure that you have [Pipenv](https://github.com/pypa/pipenv) installed
 1. Install the [openpyxl](https://bitbucket.org/openpyxl/openpyxl/src/default/) dependency - `pipenv install`
-1. Edit `run.sh` to point to your Odoo instance, with credentials that can search and create ITAD records
-1. Edit `app.py` and modify the constants (all capital letters) at the top to reflect your spreadsheet and Odoo configuration
+1. Edit `run.sh` to contain the configuration you need.
+    * Point to your Odoo instance, with credentials that can search and create ITAD records
     * Spreadsheet configuration includes: Filename (relative or absolute), the Sheet to work from, as well as the rows and columns to fetch
     * Odoo configuration includes: Asset Catalog ID and Data Destruction ID. These are both the database ids of their respective forms. Used to connect the line items to specific records
     * `SERIALS_TO_IGNORE` specifies a list of serial numbers to not check for duplicates and to always create new records
 6. Enter the virtual environment - `pipenv shell`
-1. Start the application - `./run.sh | tee output.log` - This can take a couple minutes depending on how big the spreadsheet is
+1. Start the application - `./run.sh` - This can take a couple minutes depending on how big the spreadsheet is.
+    * Normal output will be printed to the console
+    * A log file will be generated in `logs/<the epoch timestamp when started>.log` with normal output
+    * A csv file will be generated in `./<the epoch timestamp when started>.csv` that contains line items that were ignored

--- a/readme.md
+++ b/readme.md
@@ -14,7 +14,7 @@ The types of records that are created are:
 
 ## Version
 
-The current version is 1.1.0. Please check changelog.md for more information.
+The current version is 1.1.1. Please check changelog.md for more information.
 
 ## Usage
 

--- a/record.py
+++ b/record.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# Part of XLSX to Odoo import
+# Copyright 2020 David Todd <dtodd@oceantech.com>
+# License: MIT License, refer to `license.md` for more information
+
+# pylint: disable=import-error
+
+"""
+    Provides the Record class, which is a close
+    representation of an Odoo Record for the purposes
+    of importing line items.
+"""
+
+import json
+
+class Record:
+    """
+        Stores information about the line items to import.
+
+        All fields but one are expected to be of type `str`,
+        and this class will enforce that when an instance is created.
+        The only field that is not expected to be a string is
+        the `children` field, which should be a list containing
+        one or more Record objects, or None
+    """
+
+    def __init__(self, **kwargs):
+        self.serial = str(kwargs.get('serial'))
+        self.asset_tag = str(kwargs.get('asset_tag'))
+        self.make = str(kwargs.get('make'))
+        self.model = str(kwargs.get('model'))
+        self.device_type = str(kwargs.get('device_type'))
+
+        self.children = kwargs.get('children', list())
+
+        # Special case for serial numbers recorded as dell links
+        if 'dell.com' in self.serial:
+            # We assume that there are no '/' characters in the serial,
+            # and that the serial is the very last thing in the link.
+            # For dell, this is fine, as they are sturctured like:
+            # https://qrl.dell.com/H6FND42
+            self.serial = self.serial.split('/')[-1]
+
+    def __str__(self):
+        """
+            Returns the serial number of this Record instance
+        """
+        return self.serial
+
+    def __repr__(self):
+        """
+            Used when iterating over a list of Record objects
+
+            Returns a JSON serialized string that
+            represents this Record. Children will be
+            represented as a list of dictionaries or
+            `null`
+        """
+        return json.dumps({
+            'serial': self.serial,
+            'asset_tag': self.asset_tag,
+            'make': self.make,
+            'model': self.model,
+            'device_type': self.device_type,
+            'children': [
+                child.__dict__ for child in self.children
+                if child is not None
+            ] if self.children is not None else None,
+        })

--- a/record.py
+++ b/record.py
@@ -4,8 +4,6 @@
 # Copyright 2020 David Todd <dtodd@oceantech.com>
 # License: MIT License, refer to `license.md` for more information
 
-# pylint: disable=import-error
-
 """
     Provides the Record class, which is a close
     representation of an Odoo Record for the purposes

--- a/run.sh
+++ b/run.sh
@@ -3,6 +3,7 @@
 # Sets up the environment and runs the script
 
 # Odoo Connection settings
+export odoo_host='https://erp'
 export odoo_database='OceanTech'
 export odoo_user=1
 

--- a/run.sh
+++ b/run.sh
@@ -6,6 +6,7 @@
 export odoo_host='https://erp'
 export odoo_database='OceanTech'
 export odoo_user=1
+export odoo_pass=''
 
 # Odoo Records - These are the database ids of the records that contain the table/list
 export odoo_asset_catalog_id=0

--- a/run.sh
+++ b/run.sh
@@ -2,9 +2,27 @@
 
 # Sets up the environment and runs the script
 
-export odoo_host='https://erp'
+# Odoo Connection settings
 export odoo_database='OceanTech'
 export odoo_user=1
-export odoo_pass=''
+
+# Odoo Records
+export odoo_asset_catalog_id=0
+export odoo_data_destruction_id=0
+
+# Spreadsheet configuration
+export spreadsheet='<path to your spreadsheet>.xlsx/xlsm'
+export sheet='<The Sheet name with the data>'
+
+# Assumes the actual first row is a header
+export first_row=2
+# The last row there is any data we care about
+export last_row=2000
+# The last column that we care about
+export last_col=6
+
+# Serials to ignore are special cases that we should skip that line item
+declare -a serials_to_ignore=("N/A", "")
+export serials_to_ignore=${serials_to_ignore[@]}
 
 python3 app.py

--- a/run.sh
+++ b/run.sh
@@ -6,7 +6,7 @@
 export odoo_database='OceanTech'
 export odoo_user=1
 
-# Odoo Records
+# Odoo Records - These are the database ids of the records that contain the table/list
 export odoo_asset_catalog_id=0
 export odoo_data_destruction_id=0
 
@@ -22,7 +22,10 @@ export last_row=2000
 export last_col=6
 
 # Serials to ignore are special cases that we should skip that line item
-declare -a serials_to_ignore=("N/A", "")
-export serials_to_ignore=${serials_to_ignore[@]}
+# One per line.
+export serials_to_ignore=$(cat << EOF
+N/A
+EOF
+)
 
 python3 app.py


### PR DESCRIPTION
### Added

- Saving of "Serials to Ignore" to a CSV file. This is used to select lines that shouldn't be imported, but do need to be looked at carefully
- The number of rows being processed is kept track of and reported at the end of the program
- CSV files generated as a result of this program are now ignored in git
- We now keep track of the number of each type of record uploaded
- We now track instances of failed records and see the data. Normally when a record fails to be created, it is due to being a duplicate.

### Changed

- Asset lines are now checked to see if they exist in Odoo before blindly creating new records (Asset Catalog only. This is not currently on the data destruction)
- Record objects are now able to be duplicated for cases of "Serials to Ignore" (Multiple Records with the same "Serial Number")
- The Print statements have been replaced with native logging, which output to STDOUT and a file
- Configuration of this program has been moved to `run.sh`. You should not need to alter `app.py` going forward.
- The Record class has been broken out into its own file, to help with readability