### PR TITLE
Type Hints and Improved Documentation

### DIFF
--- a/.pdoc/config.mako
+++ b/.pdoc/config.mako
@@ -24,7 +24,7 @@
     #git_link_template = 'https://gitlab.com/USER/PROJECT/blob/{commit}/{path}#L{start_line}-L{end_line}'
     #git_link_template = 'https://bitbucket.org/USER/PROJECT/src/{commit}/{path}#lines-{start_line}:{end_line}'
     #git_link_template = 'https://CGIT_HOSTNAME/PROJECT/tree/{path}?id={commit}#n{start-line}'
-    git_link_template = 'https://github.com/dtodd-wipeos/xlsx-to-itad-odoo/{commit}/{path}#L{start_line}-L{end_line}'
+    git_link_template = 'https://github.com/dtodd-wipeos/xlsx-to-itad-odoo/blob/{commit}/{path}#L{start_line}-L{end_line}'
 
     # A prefix to use for every HTML hyperlink in the generated documentation.
     # No prefix results in all links being relative.

--- a/.pdoc/config.mako
+++ b/.pdoc/config.mako
@@ -1,0 +1,57 @@
+<%!
+    # Template configuration. Copy over in your template directory
+    # (used with `--template-dir`) and adapt as necessary.
+    # Note, defaults are loaded from this distribution file, so your
+    # config.mako only needs to contain values you want overridden.
+    # You can also run pdoc with `--config KEY=VALUE` to override
+    # individual values.
+
+    html_lang = 'en'
+    show_inherited_members = False
+    extract_module_toc_into_sidebar = True
+    list_class_variables_in_index = True
+    sort_identifiers = True
+    show_type_annotations = True
+
+    # Show collapsed source code block next to each item.
+    # Disabling this can improve rendering speed of large modules.
+    show_source_code = True
+
+    # If set, format links to objects in online source code repository
+    # according to this template. Supported keywords for interpolation
+    # are: commit, path, start_line, end_line.
+    #git_link_template = 'https://github.com/USER/PROJECT/blob/{commit}/{path}#L{start_line}-L{end_line}'
+    #git_link_template = 'https://gitlab.com/USER/PROJECT/blob/{commit}/{path}#L{start_line}-L{end_line}'
+    #git_link_template = 'https://bitbucket.org/USER/PROJECT/src/{commit}/{path}#lines-{start_line}:{end_line}'
+    #git_link_template = 'https://CGIT_HOSTNAME/PROJECT/tree/{path}?id={commit}#n{start-line}'
+    git_link_template = 'https://github.com/dtodd-wipeos/xlsx-to-itad-odoo/{commit}/{path}#L{start_line}-L{end_line}'
+
+    # A prefix to use for every HTML hyperlink in the generated documentation.
+    # No prefix results in all links being relative.
+    link_prefix = ''
+
+    # Enable syntax highlighting for code/source blocks by including Highlight.js
+    syntax_highlighting = True
+
+    # Set the style keyword such as 'atom-one-light' or 'github-gist'
+    #     Options: https://github.com/highlightjs/highlight.js/tree/master/src/styles
+    #     Demo: https://highlightjs.org/static/demo/
+    hljs_style = 'github'
+
+    # If set, insert Google Analytics tracking code. Value is GA
+    # tracking id (UA-XXXXXX-Y).
+    google_analytics = ''
+
+    # If set, insert Google Custom Search search bar widget above the sidebar index.
+    # The whitespace-separated tokens represent arbitrary extra queries (at least one
+    # must match) passed to regular Google search. Example:
+    #search_query = 'inurl:github.com/USER/PROJECT  site:PROJECT.github.io  site:PROJECT.website'
+    search_query = ''
+
+    # If set, render LaTeX math syntax within \(...\) (inline equations),
+    # or within \[...\] or $$...$$ or `.. math::` (block equations)
+    # as nicely-formatted math formulas using MathJax.
+    # Note: in Python docstrings, either all backslashes need to be escaped (\\)
+    # or you need to use raw r-strings.
+    latex_math = False
+%>

--- a/api.py
+++ b/api.py
@@ -31,7 +31,7 @@ class API:
     # The types of query that are able to be made to the Odoo instance
     QUERY_TYPES = ['search', 'create', 'read', 'write', 'unlink', 'search_read']
 
-    def __init__(self):
+    def __init__(self) -> None:
         """
             Gathers Odoo information from the environment and parses the required fields
         """
@@ -65,7 +65,7 @@ class API:
                 'Set this by doing `export odoo_pass=\'<your password>\'` '
                 'and run the script again')
 
-    def _connect(self):
+    def _connect(self) -> xmlrpc.client.ServerProxy:
         """
             Connects to the Odoo instance and returns an XMLRPC object
         """
@@ -77,7 +77,7 @@ class API:
             return xmlrpc.client.ServerProxy(endpoint, context=ssl._create_unverified_context())
         return xmlrpc.client.ServerProxy(endpoint)
 
-    def _query(self, query_type, model, query, options={}):
+    def _query(self, query_type: str, model: str, query: list, options: dict = {}) -> list:
         """
             Verifies the `query_type` is supported by the API
             and executes the API request on a new XMLRPC instance, returning the result
@@ -96,7 +96,7 @@ class API:
             [query],    # query must be a list containing either a list or dict depending on the query_type
             options)    # options will always be an optional dict, but the keys and values will change depending on query_type
 
-    def do_search(self, model, query=[], options={'limit':0}):
+    def do_search(self, model: str, query: list = [], options: dict = {'limit': 0}) -> list:
         """
             Searches the `model` for `query` with `options`
             Defaults to search all records with no limit.
@@ -112,7 +112,7 @@ class API:
 
         return self._query('search', model, query, options)
 
-    def do_create(self, model, query):
+    def do_create(self, model: str, query: list) -> list:
         """
             Creates one or more records on `model` with the supplied `query`
 
@@ -131,7 +131,7 @@ class API:
 
         return self._query('create', model, query)
 
-    def do_read(self, model, query, options={}):
+    def do_read(self, model: str, query: list, options: dict = {}) -> list:
         """
             Reads one or more records on `model` with the supplied `query`
 
@@ -145,7 +145,7 @@ class API:
 
         return self._query('read', model, query, options)
 
-    def do_update(self, model, query, options={}):
+    def do_update(self, model: str, query: list, options: dict = {}) -> list:
         """
             Updates one or more records on `model`, selected with `query`
 
@@ -158,7 +158,7 @@ class API:
 
         return self._query('write', model, query, options)
 
-    def do_delete(self, model, query):
+    def do_delete(self, model: str, query: list) -> list:
         """
             Deletes one or more records on `model`, selected with `query`
 
@@ -171,7 +171,7 @@ class API:
 
         return self._query('unlink', model, query)
 
-    def do_search_and_read(self, model, query, options={}):
+    def do_search_and_read(self, model: str, query: list, options: dict = {}) -> list:
         """
             Shortcut for `do_read()` with the result of `do_search()` being used as the `query`
 

--- a/app.py
+++ b/app.py
@@ -5,6 +5,11 @@
 # License: MIT License, refer to `license.md` for more information
 
 # pylint: disable=import-error
+# pylint: disable=bad-whitespace
+# pylint: disable=bad-continuation
+# pylint: disable=logging-not-lazy
+# pylint: disable=unnecessary-comprehension
+# pylint: disable=too-many-instance-attributes
 
 """
     A Really hacky script (not really), who's purpose
@@ -19,6 +24,7 @@ import csv
 import time
 import logging
 import itertools
+from typing import Union
 
 from openpyxl import load_workbook
 from record import Record
@@ -71,8 +77,7 @@ class ProcessWorkbook:
         from the workbook and uploading it to Odoo
     """
 
-    # pylint: disable=too-many-instance-attributes
-    def __init__(self):
+    def __init__(self) -> None:
         self.api = API()
         self.workbook = load_workbook(filename=SPREADSHEET, data_only=True)[SHEET]
 
@@ -113,7 +118,7 @@ class ProcessWorkbook:
 
         logging.info('Initialized ProcessWorkbook')
 
-    def __del__(self):
+    def __del__(self) -> None:
         """
             Automatically closes file handlers when destructed normally
         """
@@ -126,7 +131,6 @@ class ProcessWorkbook:
         logging.info('Prevented %d Records from being uploaded', (self.records_ignored))
 
         for row in self.failed_records:
-            # pylint: disable=logging-not-lazy
             logging.info(
                 'Row that failed Record Creation: %s | %s | %s | %s | %s' % (
                     row[0].value,
@@ -139,7 +143,7 @@ class ProcessWorkbook:
 
         logging.info('ProcessWorkbook Finished')
 
-    def get_id_from_model(self, model):
+    def get_id_from_model(self, model: str) -> Union[tuple, None]:
         """
             Searches `self.models_to_ids` for
             a matching `model`, and returns the
@@ -151,7 +155,7 @@ class ProcessWorkbook:
                 return item[1]
         return None
 
-    def serial_in_records(self, serial, records=None):
+    def serial_in_records(self, serial: str, records: Record = None) -> bool:
         """
             Determines if a particular serial number
             is in a record list, and returns True if so;
@@ -177,7 +181,9 @@ class ProcessWorkbook:
             return True
         return False
 
-    def create_record_from_row(self, row, parent=True, search_model=True):
+    def create_record_from_row(
+        self, row: tuple, parent: bool = True, search_model: bool = True
+    ) -> Union[bool, Record]:
         """
             With a provided `row`, this method will first search
             for a matching serial number and if it doesn't exist,
@@ -199,7 +205,6 @@ class ProcessWorkbook:
 
         serial = str(row[0].value)
         if not self.serial_in_records(serial):
-            # pylint: disable=bad-whitespace
             logging.debug('Creating Record for %s', (serial))
             record = Record(
                 serial = serial,
@@ -222,7 +227,7 @@ class ProcessWorkbook:
             return record
         return False
 
-    def build_record_list(self):
+    def build_record_list(self) -> 'ProcessWorkbook':
         """
             Reads the workbook and sorts each row into
             multiple instances of the Record class.
@@ -242,7 +247,6 @@ class ProcessWorkbook:
             Returns `self` (this instance of ProcessWorkbook)
         """
         logging.info('Getting rows from the spreadsheet and sorting relationships')
-        # pylint: disable=bad-continuation
         for row in self.workbook.iter_rows(
             min_row=FIRST_ROW,
             max_col=LAST_COL,
@@ -273,7 +277,7 @@ class ProcessWorkbook:
 
         return self
 
-    def get_records(self):
+    def get_records(self) -> 'ProcessWorkbook':
         """
             Deprecated, use `build_record_list` instead.
         """
@@ -281,14 +285,13 @@ class ProcessWorkbook:
         logging.warning('Please use `build_record_list` instead.')
         return self.build_record_list()
 
-    def show_records(self):
+    def show_records(self) -> None:
         """
             Logs all of the records stored, in JSON format
         """
-        # pylint: disable=unnecessary-comprehension
         logging.debug([record for record in self.records])
 
-    def get_odoo_model_ids(self):
+    def get_odoo_model_ids(self) -> 'ProcessWorkbook':
         """
             Iterates over unique models and searches
             Odoo for the database id of those models.
@@ -322,7 +325,7 @@ class ProcessWorkbook:
                 # models are duplicated (for whatever reason)
                 self.models_to_ids.append((model, odoo_records[0]['id']))
 
-    def create_missing_model_ids(self):
+    def create_missing_model_ids(self) -> 'ProcessWorkbook':
         """
             For any models that couldn't be located
             when initally searched, create them and
@@ -344,7 +347,7 @@ class ProcessWorkbook:
 
         return self
 
-    def asset_line_exists(self, record):
+    def asset_line_exists(self, record: Record) -> bool:
         """
             Searches the asset catalog for
             a line item matching the provided `record`.
@@ -368,7 +371,7 @@ class ProcessWorkbook:
             return True
         return False
 
-    def _create_asset_catalog_line(self, record):
+    def _create_asset_catalog_line(self, record: Record) -> 'ProcessWorkbook':
         """
             With the provided `record` (Record) instance,
             this method will issue an API request to Odoo
@@ -395,7 +398,9 @@ class ProcessWorkbook:
 
         return self
 
-    def _create_data_destruction_line(self, record, child=False):
+    def _create_data_destruction_line(
+        self, record: Record, child: bool = False
+    ) -> 'ProcessWorkbook':
         """
             With the provided `record` and optional `child` Record
             instances, this method will issue an API request to
@@ -435,7 +440,7 @@ class ProcessWorkbook:
 
         return self
 
-    def create_line_items(self):
+    def create_line_items(self) -> 'ProcessWorkbook':
         """
             For all the records that we can
             process (there's a mapped model),
@@ -459,7 +464,7 @@ class ProcessWorkbook:
 
         return self
 
-    def remove_ignored_records(self):
+    def remove_ignored_records(self) -> None:
         """
             Populates `self.records_to_upload` with
             any record that is not also a part of the
@@ -486,7 +491,7 @@ class ProcessWorkbook:
             else:
                 self.records_to_upload.append(record)
 
-    def run(self):
+    def run(self) -> None:
         """
             Runs everything in the order that is required
         """

--- a/document.sh
+++ b/document.sh
@@ -3,4 +3,4 @@
 # Sets up the environment and runs the script
 source config.sh
 
-pdoc --force --html .
+pdoc --template-dir .pdoc --force --html .

--- a/exceptions.py
+++ b/exceptions.py
@@ -16,6 +16,6 @@ class InputError(Exception):
                 for how to fix it
     """
 
-    def __init__(self, field, message):
+    def __init__(self, field: str, message: str) -> Exception:
         self.field = field
         self.message = message

--- a/html/xlsx-to-itad-odoo/api.html
+++ b/html/xlsx-to-itad-odoo/api.html
@@ -23,7 +23,7 @@
 <details class="source">
 <summary>
 <span>Expand source code</span>
-<a href="https://github.com/dtodd-wipeos/xlsx-to-itad-odoo/6b5eba7862c8f641ff0f768615c9a69b76ff8430/api.py#L0-L185" class="git-link">Browse git</a>
+<a href="https://github.com/dtodd-wipeos/xlsx-to-itad-odoo/blob/fdb1682d276e659c77195ec91a12af2c95695046/api.py#L0-L185" class="git-link">Browse git</a>
 </summary>
 <pre><code class="python">#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
@@ -237,7 +237,7 @@ and to perform queries against the database.</p>
 <details class="source">
 <summary>
 <span>Expand source code</span>
-<a href="https://github.com/dtodd-wipeos/xlsx-to-itad-odoo/6b5eba7862c8f641ff0f768615c9a69b76ff8430/api.py#L19-L186" class="git-link">Browse git</a>
+<a href="https://github.com/dtodd-wipeos/xlsx-to-itad-odoo/blob/fdb1682d276e659c77195ec91a12af2c95695046/api.py#L19-L186" class="git-link">Browse git</a>
 </summary>
 <pre><code class="python">class API:
     &#34;&#34;&#34;
@@ -433,7 +433,7 @@ Relational fields (<code>one2many</code>, <code>many2one</code>, <code>many2many
 <details class="source">
 <summary>
 <span>Expand source code</span>
-<a href="https://github.com/dtodd-wipeos/xlsx-to-itad-odoo/6b5eba7862c8f641ff0f768615c9a69b76ff8430/api.py#L115-L132" class="git-link">Browse git</a>
+<a href="https://github.com/dtodd-wipeos/xlsx-to-itad-odoo/blob/fdb1682d276e659c77195ec91a12af2c95695046/api.py#L115-L132" class="git-link">Browse git</a>
 </summary>
 <pre><code class="python">def do_create(self, model: str, query: list) -&gt; list:
     &#34;&#34;&#34;
@@ -466,7 +466,7 @@ Relational fields (<code>one2many</code>, <code>many2one</code>, <code>many2many
 <details class="source">
 <summary>
 <span>Expand source code</span>
-<a href="https://github.com/dtodd-wipeos/xlsx-to-itad-odoo/6b5eba7862c8f641ff0f768615c9a69b76ff8430/api.py#L161-L172" class="git-link">Browse git</a>
+<a href="https://github.com/dtodd-wipeos/xlsx-to-itad-odoo/blob/fdb1682d276e659c77195ec91a12af2c95695046/api.py#L161-L172" class="git-link">Browse git</a>
 </summary>
 <pre><code class="python">def do_delete(self, model: str, query: list) -&gt; list:
     &#34;&#34;&#34;
@@ -494,7 +494,7 @@ Relational fields (<code>one2many</code>, <code>many2one</code>, <code>many2many
 <details class="source">
 <summary>
 <span>Expand source code</span>
-<a href="https://github.com/dtodd-wipeos/xlsx-to-itad-odoo/6b5eba7862c8f641ff0f768615c9a69b76ff8430/api.py#L134-L146" class="git-link">Browse git</a>
+<a href="https://github.com/dtodd-wipeos/xlsx-to-itad-odoo/blob/fdb1682d276e659c77195ec91a12af2c95695046/api.py#L134-L146" class="git-link">Browse git</a>
 </summary>
 <pre><code class="python">def do_read(self, model: str, query: list, options: dict = {}) -&gt; list:
     &#34;&#34;&#34;
@@ -525,7 +525,7 @@ Defaults to search all records with no limit.</p>
 <details class="source">
 <summary>
 <span>Expand source code</span>
-<a href="https://github.com/dtodd-wipeos/xlsx-to-itad-odoo/6b5eba7862c8f641ff0f768615c9a69b76ff8430/api.py#L99-L113" class="git-link">Browse git</a>
+<a href="https://github.com/dtodd-wipeos/xlsx-to-itad-odoo/blob/fdb1682d276e659c77195ec91a12af2c95695046/api.py#L99-L113" class="git-link">Browse git</a>
 </summary>
 <pre><code class="python">def do_search(self, model: str, query: list = [], options: dict = {&#39;limit&#39;: 0}) -&gt; list:
     &#34;&#34;&#34;
@@ -556,7 +556,7 @@ Defaults to search all records with no limit.</p>
 <details class="source">
 <summary>
 <span>Expand source code</span>
-<a href="https://github.com/dtodd-wipeos/xlsx-to-itad-odoo/6b5eba7862c8f641ff0f768615c9a69b76ff8430/api.py#L174-L186" class="git-link">Browse git</a>
+<a href="https://github.com/dtodd-wipeos/xlsx-to-itad-odoo/blob/fdb1682d276e659c77195ec91a12af2c95695046/api.py#L174-L186" class="git-link">Browse git</a>
 </summary>
 <pre><code class="python">def do_search_and_read(self, model: str, query: list, options: dict = {}) -&gt; list:
     &#34;&#34;&#34;
@@ -584,7 +584,7 @@ Defaults to search all records with no limit.</p>
 <details class="source">
 <summary>
 <span>Expand source code</span>
-<a href="https://github.com/dtodd-wipeos/xlsx-to-itad-odoo/6b5eba7862c8f641ff0f768615c9a69b76ff8430/api.py#L148-L159" class="git-link">Browse git</a>
+<a href="https://github.com/dtodd-wipeos/xlsx-to-itad-odoo/blob/fdb1682d276e659c77195ec91a12af2c95695046/api.py#L148-L159" class="git-link">Browse git</a>
 </summary>
 <pre><code class="python">def do_update(self, model: str, query: list, options: dict = {}) -&gt; list:
     &#34;&#34;&#34;

--- a/html/xlsx-to-itad-odoo/api.html
+++ b/html/xlsx-to-itad-odoo/api.html
@@ -57,7 +57,7 @@ class API:
     # The types of query that are able to be made to the Odoo instance
     QUERY_TYPES = [&#39;search&#39;, &#39;create&#39;, &#39;read&#39;, &#39;write&#39;, &#39;unlink&#39;, &#39;search_read&#39;]
 
-    def __init__(self):
+    def __init__(self) -&gt; None:
         &#34;&#34;&#34;
             Gathers Odoo information from the environment and parses the required fields
         &#34;&#34;&#34;
@@ -91,7 +91,7 @@ class API:
                 &#39;Set this by doing `export odoo_pass=\&#39;&lt;your password&gt;\&#39;` &#39;
                 &#39;and run the script again&#39;)
 
-    def _connect(self):
+    def _connect(self) -&gt; xmlrpc.client.ServerProxy:
         &#34;&#34;&#34;
             Connects to the Odoo instance and returns an XMLRPC object
         &#34;&#34;&#34;
@@ -103,7 +103,7 @@ class API:
             return xmlrpc.client.ServerProxy(endpoint, context=ssl._create_unverified_context())
         return xmlrpc.client.ServerProxy(endpoint)
 
-    def _query(self, query_type, model, query, options={}):
+    def _query(self, query_type: str, model: str, query: list, options: dict = {}) -&gt; list:
         &#34;&#34;&#34;
             Verifies the `query_type` is supported by the API
             and executes the API request on a new XMLRPC instance, returning the result
@@ -122,7 +122,7 @@ class API:
             [query],    # query must be a list containing either a list or dict depending on the query_type
             options)    # options will always be an optional dict, but the keys and values will change depending on query_type
 
-    def do_search(self, model, query=[], options={&#39;limit&#39;:0}):
+    def do_search(self, model: str, query: list = [], options: dict = {&#39;limit&#39;: 0}) -&gt; list:
         &#34;&#34;&#34;
             Searches the `model` for `query` with `options`
             Defaults to search all records with no limit.
@@ -138,7 +138,7 @@ class API:
 
         return self._query(&#39;search&#39;, model, query, options)
 
-    def do_create(self, model, query):
+    def do_create(self, model: str, query: list) -&gt; list:
         &#34;&#34;&#34;
             Creates one or more records on `model` with the supplied `query`
 
@@ -157,7 +157,7 @@ class API:
 
         return self._query(&#39;create&#39;, model, query)
 
-    def do_read(self, model, query, options={}):
+    def do_read(self, model: str, query: list, options: dict = {}) -&gt; list:
         &#34;&#34;&#34;
             Reads one or more records on `model` with the supplied `query`
 
@@ -171,7 +171,7 @@ class API:
 
         return self._query(&#39;read&#39;, model, query, options)
 
-    def do_update(self, model, query, options={}):
+    def do_update(self, model: str, query: list, options: dict = {}) -&gt; list:
         &#34;&#34;&#34;
             Updates one or more records on `model`, selected with `query`
 
@@ -184,7 +184,7 @@ class API:
 
         return self._query(&#39;write&#39;, model, query, options)
 
-    def do_delete(self, model, query):
+    def do_delete(self, model: str, query: list) -&gt; list:
         &#34;&#34;&#34;
             Deletes one or more records on `model`, selected with `query`
 
@@ -197,7 +197,7 @@ class API:
 
         return self._query(&#39;unlink&#39;, model, query)
 
-    def do_search_and_read(self, model, query, options={}):
+    def do_search_and_read(self, model: str, query: list, options: dict = {}) -&gt; list:
         &#34;&#34;&#34;
             Shortcut for `do_read()` with the result of `do_search()` being used as the `query`
 
@@ -252,7 +252,7 @@ and to perform queries against the database.</p>
     # The types of query that are able to be made to the Odoo instance
     QUERY_TYPES = [&#39;search&#39;, &#39;create&#39;, &#39;read&#39;, &#39;write&#39;, &#39;unlink&#39;, &#39;search_read&#39;]
 
-    def __init__(self):
+    def __init__(self) -&gt; None:
         &#34;&#34;&#34;
             Gathers Odoo information from the environment and parses the required fields
         &#34;&#34;&#34;
@@ -286,7 +286,7 @@ and to perform queries against the database.</p>
                 &#39;Set this by doing `export odoo_pass=\&#39;&lt;your password&gt;\&#39;` &#39;
                 &#39;and run the script again&#39;)
 
-    def _connect(self):
+    def _connect(self) -&gt; xmlrpc.client.ServerProxy:
         &#34;&#34;&#34;
             Connects to the Odoo instance and returns an XMLRPC object
         &#34;&#34;&#34;
@@ -298,7 +298,7 @@ and to perform queries against the database.</p>
             return xmlrpc.client.ServerProxy(endpoint, context=ssl._create_unverified_context())
         return xmlrpc.client.ServerProxy(endpoint)
 
-    def _query(self, query_type, model, query, options={}):
+    def _query(self, query_type: str, model: str, query: list, options: dict = {}) -&gt; list:
         &#34;&#34;&#34;
             Verifies the `query_type` is supported by the API
             and executes the API request on a new XMLRPC instance, returning the result
@@ -317,7 +317,7 @@ and to perform queries against the database.</p>
             [query],    # query must be a list containing either a list or dict depending on the query_type
             options)    # options will always be an optional dict, but the keys and values will change depending on query_type
 
-    def do_search(self, model, query=[], options={&#39;limit&#39;:0}):
+    def do_search(self, model: str, query: list = [], options: dict = {&#39;limit&#39;: 0}) -&gt; list:
         &#34;&#34;&#34;
             Searches the `model` for `query` with `options`
             Defaults to search all records with no limit.
@@ -333,7 +333,7 @@ and to perform queries against the database.</p>
 
         return self._query(&#39;search&#39;, model, query, options)
 
-    def do_create(self, model, query):
+    def do_create(self, model: str, query: list) -&gt; list:
         &#34;&#34;&#34;
             Creates one or more records on `model` with the supplied `query`
 
@@ -352,7 +352,7 @@ and to perform queries against the database.</p>
 
         return self._query(&#39;create&#39;, model, query)
 
-    def do_read(self, model, query, options={}):
+    def do_read(self, model: str, query: list, options: dict = {}) -&gt; list:
         &#34;&#34;&#34;
             Reads one or more records on `model` with the supplied `query`
 
@@ -366,7 +366,7 @@ and to perform queries against the database.</p>
 
         return self._query(&#39;read&#39;, model, query, options)
 
-    def do_update(self, model, query, options={}):
+    def do_update(self, model: str, query: list, options: dict = {}) -&gt; list:
         &#34;&#34;&#34;
             Updates one or more records on `model`, selected with `query`
 
@@ -379,7 +379,7 @@ and to perform queries against the database.</p>
 
         return self._query(&#39;write&#39;, model, query, options)
 
-    def do_delete(self, model, query):
+    def do_delete(self, model: str, query: list) -&gt; list:
         &#34;&#34;&#34;
             Deletes one or more records on `model`, selected with `query`
 
@@ -392,7 +392,7 @@ and to perform queries against the database.</p>
 
         return self._query(&#39;unlink&#39;, model, query)
 
-    def do_search_and_read(self, model, query, options={}):
+    def do_search_and_read(self, model: str, query: list, options: dict = {}) -&gt; list:
         &#34;&#34;&#34;
             Shortcut for `do_read()` with the result of `do_search()` being used as the `query`
 
@@ -416,7 +416,7 @@ and to perform queries against the database.</p>
 <h3>Methods</h3>
 <dl>
 <dt id="xlsx-to-itad-odoo.api.API.do_create"><code class="name flex">
-<span>def <span class="ident">do_create</span></span>(<span>self, model, query)</span>
+<span>def <span class="ident">do_create</span></span>(<span>self, model: str, query: list) -> list</span>
 </code></dt>
 <dd>
 <div class="desc"><p>Creates one or more records on <code>model</code> with the supplied <code>query</code></p>
@@ -432,7 +432,7 @@ Relational fields (<code>one2many</code>, <code>many2one</code>, <code>many2many
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">def do_create(self, model, query):
+<pre><code class="python">def do_create(self, model: str, query: list) -&gt; list:
     &#34;&#34;&#34;
         Creates one or more records on `model` with the supplied `query`
 
@@ -453,7 +453,7 @@ Relational fields (<code>one2many</code>, <code>many2one</code>, <code>many2many
 </details>
 </dd>
 <dt id="xlsx-to-itad-odoo.api.API.do_delete"><code class="name flex">
-<span>def <span class="ident">do_delete</span></span>(<span>self, model, query)</span>
+<span>def <span class="ident">do_delete</span></span>(<span>self, model: str, query: list) -> list</span>
 </code></dt>
 <dd>
 <div class="desc"><p>Deletes one or more records on <code>model</code>, selected with <code>query</code></p>
@@ -464,7 +464,7 @@ Relational fields (<code>one2many</code>, <code>many2one</code>, <code>many2many
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">def do_delete(self, model, query):
+<pre><code class="python">def do_delete(self, model: str, query: list) -&gt; list:
     &#34;&#34;&#34;
         Deletes one or more records on `model`, selected with `query`
 
@@ -479,7 +479,7 @@ Relational fields (<code>one2many</code>, <code>many2one</code>, <code>many2many
 </details>
 </dd>
 <dt id="xlsx-to-itad-odoo.api.API.do_read"><code class="name flex">
-<span>def <span class="ident">do_read</span></span>(<span>self, model, query, options={})</span>
+<span>def <span class="ident">do_read</span></span>(<span>self, model: str, query: list, options: dict = {}) -> list</span>
 </code></dt>
 <dd>
 <div class="desc"><p>Reads one or more records on <code>model</code> with the supplied <code>query</code></p>
@@ -491,7 +491,7 @@ Relational fields (<code>one2many</code>, <code>many2one</code>, <code>many2many
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">def do_read(self, model, query, options={}):
+<pre><code class="python">def do_read(self, model: str, query: list, options: dict = {}) -&gt; list:
     &#34;&#34;&#34;
         Reads one or more records on `model` with the supplied `query`
 
@@ -507,7 +507,7 @@ Relational fields (<code>one2many</code>, <code>many2one</code>, <code>many2many
 </details>
 </dd>
 <dt id="xlsx-to-itad-odoo.api.API.do_search"><code class="name flex">
-<span>def <span class="ident">do_search</span></span>(<span>self, model, query=[], options={'limit': 0})</span>
+<span>def <span class="ident">do_search</span></span>(<span>self, model: str, query: list = [], options: dict = {'limit': 0}) -> list</span>
 </code></dt>
 <dd>
 <div class="desc"><p>Searches the <code>model</code> for <code>query</code> with <code>options</code>
@@ -521,7 +521,7 @@ Defaults to search all records with no limit.</p>
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">def do_search(self, model, query=[], options={&#39;limit&#39;:0}):
+<pre><code class="python">def do_search(self, model: str, query: list = [], options: dict = {&#39;limit&#39;: 0}) -&gt; list:
     &#34;&#34;&#34;
         Searches the `model` for `query` with `options`
         Defaults to search all records with no limit.
@@ -539,7 +539,7 @@ Defaults to search all records with no limit.</p>
 </details>
 </dd>
 <dt id="xlsx-to-itad-odoo.api.API.do_search_and_read"><code class="name flex">
-<span>def <span class="ident">do_search_and_read</span></span>(<span>self, model, query, options={})</span>
+<span>def <span class="ident">do_search_and_read</span></span>(<span>self, model: str, query: list, options: dict = {}) -> list</span>
 </code></dt>
 <dd>
 <div class="desc"><p>Shortcut for <code>do_read()</code> with the result of <code>do_search()</code> being used as the <code>query</code></p>
@@ -551,7 +551,7 @@ Defaults to search all records with no limit.</p>
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">def do_search_and_read(self, model, query, options={}):
+<pre><code class="python">def do_search_and_read(self, model: str, query: list, options: dict = {}) -&gt; list:
     &#34;&#34;&#34;
         Shortcut for `do_read()` with the result of `do_search()` being used as the `query`
 
@@ -567,7 +567,7 @@ Defaults to search all records with no limit.</p>
 </details>
 </dd>
 <dt id="xlsx-to-itad-odoo.api.API.do_update"><code class="name flex">
-<span>def <span class="ident">do_update</span></span>(<span>self, model, query, options={})</span>
+<span>def <span class="ident">do_update</span></span>(<span>self, model: str, query: list, options: dict = {}) -> list</span>
 </code></dt>
 <dd>
 <div class="desc"><p>Updates one or more records on <code>model</code>, selected with <code>query</code></p>
@@ -578,7 +578,7 @@ Defaults to search all records with no limit.</p>
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">def do_update(self, model, query, options={}):
+<pre><code class="python">def do_update(self, model: str, query: list, options: dict = {}) -&gt; list:
     &#34;&#34;&#34;
         Updates one or more records on `model`, selected with `query`
 

--- a/html/xlsx-to-itad-odoo/api.html
+++ b/html/xlsx-to-itad-odoo/api.html
@@ -23,7 +23,7 @@
 <details class="source">
 <summary>
 <span>Expand source code</span>
-<a href="https://github.com/dtodd-wipeos/xlsx-to-itad-odoo/blob/fdb1682d276e659c77195ec91a12af2c95695046/api.py#L0-L185" class="git-link">Browse git</a>
+<a href="https://github.com/dtodd-wipeos/xlsx-to-itad-odoo/blob/0fb9ed425228ba9ac132fed71442920c50f9bf6a/api.py#L0-L185" class="git-link">Browse git</a>
 </summary>
 <pre><code class="python">#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
@@ -237,7 +237,7 @@ and to perform queries against the database.</p>
 <details class="source">
 <summary>
 <span>Expand source code</span>
-<a href="https://github.com/dtodd-wipeos/xlsx-to-itad-odoo/blob/fdb1682d276e659c77195ec91a12af2c95695046/api.py#L19-L186" class="git-link">Browse git</a>
+<a href="https://github.com/dtodd-wipeos/xlsx-to-itad-odoo/blob/0fb9ed425228ba9ac132fed71442920c50f9bf6a/api.py#L19-L186" class="git-link">Browse git</a>
 </summary>
 <pre><code class="python">class API:
     &#34;&#34;&#34;
@@ -433,7 +433,7 @@ Relational fields (<code>one2many</code>, <code>many2one</code>, <code>many2many
 <details class="source">
 <summary>
 <span>Expand source code</span>
-<a href="https://github.com/dtodd-wipeos/xlsx-to-itad-odoo/blob/fdb1682d276e659c77195ec91a12af2c95695046/api.py#L115-L132" class="git-link">Browse git</a>
+<a href="https://github.com/dtodd-wipeos/xlsx-to-itad-odoo/blob/0fb9ed425228ba9ac132fed71442920c50f9bf6a/api.py#L115-L132" class="git-link">Browse git</a>
 </summary>
 <pre><code class="python">def do_create(self, model: str, query: list) -&gt; list:
     &#34;&#34;&#34;
@@ -466,7 +466,7 @@ Relational fields (<code>one2many</code>, <code>many2one</code>, <code>many2many
 <details class="source">
 <summary>
 <span>Expand source code</span>
-<a href="https://github.com/dtodd-wipeos/xlsx-to-itad-odoo/blob/fdb1682d276e659c77195ec91a12af2c95695046/api.py#L161-L172" class="git-link">Browse git</a>
+<a href="https://github.com/dtodd-wipeos/xlsx-to-itad-odoo/blob/0fb9ed425228ba9ac132fed71442920c50f9bf6a/api.py#L161-L172" class="git-link">Browse git</a>
 </summary>
 <pre><code class="python">def do_delete(self, model: str, query: list) -&gt; list:
     &#34;&#34;&#34;
@@ -494,7 +494,7 @@ Relational fields (<code>one2many</code>, <code>many2one</code>, <code>many2many
 <details class="source">
 <summary>
 <span>Expand source code</span>
-<a href="https://github.com/dtodd-wipeos/xlsx-to-itad-odoo/blob/fdb1682d276e659c77195ec91a12af2c95695046/api.py#L134-L146" class="git-link">Browse git</a>
+<a href="https://github.com/dtodd-wipeos/xlsx-to-itad-odoo/blob/0fb9ed425228ba9ac132fed71442920c50f9bf6a/api.py#L134-L146" class="git-link">Browse git</a>
 </summary>
 <pre><code class="python">def do_read(self, model: str, query: list, options: dict = {}) -&gt; list:
     &#34;&#34;&#34;
@@ -525,7 +525,7 @@ Defaults to search all records with no limit.</p>
 <details class="source">
 <summary>
 <span>Expand source code</span>
-<a href="https://github.com/dtodd-wipeos/xlsx-to-itad-odoo/blob/fdb1682d276e659c77195ec91a12af2c95695046/api.py#L99-L113" class="git-link">Browse git</a>
+<a href="https://github.com/dtodd-wipeos/xlsx-to-itad-odoo/blob/0fb9ed425228ba9ac132fed71442920c50f9bf6a/api.py#L99-L113" class="git-link">Browse git</a>
 </summary>
 <pre><code class="python">def do_search(self, model: str, query: list = [], options: dict = {&#39;limit&#39;: 0}) -&gt; list:
     &#34;&#34;&#34;
@@ -556,7 +556,7 @@ Defaults to search all records with no limit.</p>
 <details class="source">
 <summary>
 <span>Expand source code</span>
-<a href="https://github.com/dtodd-wipeos/xlsx-to-itad-odoo/blob/fdb1682d276e659c77195ec91a12af2c95695046/api.py#L174-L186" class="git-link">Browse git</a>
+<a href="https://github.com/dtodd-wipeos/xlsx-to-itad-odoo/blob/0fb9ed425228ba9ac132fed71442920c50f9bf6a/api.py#L174-L186" class="git-link">Browse git</a>
 </summary>
 <pre><code class="python">def do_search_and_read(self, model: str, query: list, options: dict = {}) -&gt; list:
     &#34;&#34;&#34;
@@ -584,7 +584,7 @@ Defaults to search all records with no limit.</p>
 <details class="source">
 <summary>
 <span>Expand source code</span>
-<a href="https://github.com/dtodd-wipeos/xlsx-to-itad-odoo/blob/fdb1682d276e659c77195ec91a12af2c95695046/api.py#L148-L159" class="git-link">Browse git</a>
+<a href="https://github.com/dtodd-wipeos/xlsx-to-itad-odoo/blob/0fb9ed425228ba9ac132fed71442920c50f9bf6a/api.py#L148-L159" class="git-link">Browse git</a>
 </summary>
 <pre><code class="python">def do_update(self, model: str, query: list, options: dict = {}) -&gt; list:
     &#34;&#34;&#34;

--- a/html/xlsx-to-itad-odoo/api.html
+++ b/html/xlsx-to-itad-odoo/api.html
@@ -23,6 +23,7 @@
 <details class="source">
 <summary>
 <span>Expand source code</span>
+<a href="https://github.com/dtodd-wipeos/xlsx-to-itad-odoo/6b5eba7862c8f641ff0f768615c9a69b76ff8430/api.py#L0-L185" class="git-link">Browse git</a>
 </summary>
 <pre><code class="python">#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
@@ -236,6 +237,7 @@ and to perform queries against the database.</p>
 <details class="source">
 <summary>
 <span>Expand source code</span>
+<a href="https://github.com/dtodd-wipeos/xlsx-to-itad-odoo/6b5eba7862c8f641ff0f768615c9a69b76ff8430/api.py#L19-L186" class="git-link">Browse git</a>
 </summary>
 <pre><code class="python">class API:
     &#34;&#34;&#34;
@@ -431,6 +433,7 @@ Relational fields (<code>one2many</code>, <code>many2one</code>, <code>many2many
 <details class="source">
 <summary>
 <span>Expand source code</span>
+<a href="https://github.com/dtodd-wipeos/xlsx-to-itad-odoo/6b5eba7862c8f641ff0f768615c9a69b76ff8430/api.py#L115-L132" class="git-link">Browse git</a>
 </summary>
 <pre><code class="python">def do_create(self, model: str, query: list) -&gt; list:
     &#34;&#34;&#34;
@@ -463,6 +466,7 @@ Relational fields (<code>one2many</code>, <code>many2one</code>, <code>many2many
 <details class="source">
 <summary>
 <span>Expand source code</span>
+<a href="https://github.com/dtodd-wipeos/xlsx-to-itad-odoo/6b5eba7862c8f641ff0f768615c9a69b76ff8430/api.py#L161-L172" class="git-link">Browse git</a>
 </summary>
 <pre><code class="python">def do_delete(self, model: str, query: list) -&gt; list:
     &#34;&#34;&#34;
@@ -490,6 +494,7 @@ Relational fields (<code>one2many</code>, <code>many2one</code>, <code>many2many
 <details class="source">
 <summary>
 <span>Expand source code</span>
+<a href="https://github.com/dtodd-wipeos/xlsx-to-itad-odoo/6b5eba7862c8f641ff0f768615c9a69b76ff8430/api.py#L134-L146" class="git-link">Browse git</a>
 </summary>
 <pre><code class="python">def do_read(self, model: str, query: list, options: dict = {}) -&gt; list:
     &#34;&#34;&#34;
@@ -520,6 +525,7 @@ Defaults to search all records with no limit.</p>
 <details class="source">
 <summary>
 <span>Expand source code</span>
+<a href="https://github.com/dtodd-wipeos/xlsx-to-itad-odoo/6b5eba7862c8f641ff0f768615c9a69b76ff8430/api.py#L99-L113" class="git-link">Browse git</a>
 </summary>
 <pre><code class="python">def do_search(self, model: str, query: list = [], options: dict = {&#39;limit&#39;: 0}) -&gt; list:
     &#34;&#34;&#34;
@@ -550,6 +556,7 @@ Defaults to search all records with no limit.</p>
 <details class="source">
 <summary>
 <span>Expand source code</span>
+<a href="https://github.com/dtodd-wipeos/xlsx-to-itad-odoo/6b5eba7862c8f641ff0f768615c9a69b76ff8430/api.py#L174-L186" class="git-link">Browse git</a>
 </summary>
 <pre><code class="python">def do_search_and_read(self, model: str, query: list, options: dict = {}) -&gt; list:
     &#34;&#34;&#34;
@@ -577,6 +584,7 @@ Defaults to search all records with no limit.</p>
 <details class="source">
 <summary>
 <span>Expand source code</span>
+<a href="https://github.com/dtodd-wipeos/xlsx-to-itad-odoo/6b5eba7862c8f641ff0f768615c9a69b76ff8430/api.py#L148-L159" class="git-link">Browse git</a>
 </summary>
 <pre><code class="python">def do_update(self, model: str, query: list, options: dict = {}) -&gt; list:
     &#34;&#34;&#34;

--- a/html/xlsx-to-itad-odoo/app.html
+++ b/html/xlsx-to-itad-odoo/app.html
@@ -31,7 +31,7 @@ the XMLRPC interface</p>
 <details class="source">
 <summary>
 <span>Expand source code</span>
-<a href="https://github.com/dtodd-wipeos/xlsx-to-itad-odoo/blob/fdb1682d276e659c77195ec91a12af2c95695046/app.py#L0-L505" class="git-link">Browse git</a>
+<a href="https://github.com/dtodd-wipeos/xlsx-to-itad-odoo/blob/0fb9ed425228ba9ac132fed71442920c50f9bf6a/app.py#L0-L505" class="git-link">Browse git</a>
 </summary>
 <pre><code class="python">#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
@@ -559,7 +559,7 @@ from the workbook and uploading it to Odoo</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
-<a href="https://github.com/dtodd-wipeos/xlsx-to-itad-odoo/blob/fdb1682d276e659c77195ec91a12af2c95695046/app.py#L74-L503" class="git-link">Browse git</a>
+<a href="https://github.com/dtodd-wipeos/xlsx-to-itad-odoo/blob/0fb9ed425228ba9ac132fed71442920c50f9bf6a/app.py#L74-L503" class="git-link">Browse git</a>
 </summary>
 <pre><code class="python">class ProcessWorkbook:
     &#34;&#34;&#34;
@@ -1007,7 +1007,7 @@ False otherwise.</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
-<a href="https://github.com/dtodd-wipeos/xlsx-to-itad-odoo/blob/fdb1682d276e659c77195ec91a12af2c95695046/app.py#L350-L372" class="git-link">Browse git</a>
+<a href="https://github.com/dtodd-wipeos/xlsx-to-itad-odoo/blob/0fb9ed425228ba9ac132fed71442920c50f9bf6a/app.py#L350-L372" class="git-link">Browse git</a>
 </summary>
 <pre><code class="python">def asset_line_exists(self, record: Record) -&gt; bool:
     &#34;&#34;&#34;
@@ -1053,7 +1053,7 @@ will still be created, without any Children</p>
 <details class="source">
 <summary>
 <span>Expand source code</span>
-<a href="https://github.com/dtodd-wipeos/xlsx-to-itad-odoo/blob/fdb1682d276e659c77195ec91a12af2c95695046/app.py#L230-L278" class="git-link">Browse git</a>
+<a href="https://github.com/dtodd-wipeos/xlsx-to-itad-odoo/blob/0fb9ed425228ba9ac132fed71442920c50f9bf6a/app.py#L230-L278" class="git-link">Browse git</a>
 </summary>
 <pre><code class="python">def build_record_list(self) -&gt; &#39;ProcessWorkbook&#39;:
     &#34;&#34;&#34;
@@ -1118,7 +1118,7 @@ data destruction line items.</p>
 <details class="source">
 <summary>
 <span>Expand source code</span>
-<a href="https://github.com/dtodd-wipeos/xlsx-to-itad-odoo/blob/fdb1682d276e659c77195ec91a12af2c95695046/app.py#L443-L465" class="git-link">Browse git</a>
+<a href="https://github.com/dtodd-wipeos/xlsx-to-itad-odoo/blob/0fb9ed425228ba9ac132fed71442920c50f9bf6a/app.py#L443-L465" class="git-link">Browse git</a>
 </summary>
 <pre><code class="python">def create_line_items(self) -&gt; &#39;ProcessWorkbook&#39;:
     &#34;&#34;&#34;
@@ -1156,7 +1156,7 @@ then store those newly created ids</p>
 <details class="source">
 <summary>
 <span>Expand source code</span>
-<a href="https://github.com/dtodd-wipeos/xlsx-to-itad-odoo/blob/fdb1682d276e659c77195ec91a12af2c95695046/app.py#L328-L348" class="git-link">Browse git</a>
+<a href="https://github.com/dtodd-wipeos/xlsx-to-itad-odoo/blob/0fb9ed425228ba9ac132fed71442920c50f9bf6a/app.py#L328-L348" class="git-link">Browse git</a>
 </summary>
 <pre><code class="python">def create_missing_model_ids(self) -&gt; &#39;ProcessWorkbook&#39;:
     &#34;&#34;&#34;
@@ -1201,7 +1201,7 @@ created Record object. Otherwise, it returns False</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
-<a href="https://github.com/dtodd-wipeos/xlsx-to-itad-odoo/blob/fdb1682d276e659c77195ec91a12af2c95695046/app.py#L184-L228" class="git-link">Browse git</a>
+<a href="https://github.com/dtodd-wipeos/xlsx-to-itad-odoo/blob/0fb9ed425228ba9ac132fed71442920c50f9bf6a/app.py#L184-L228" class="git-link">Browse git</a>
 </summary>
 <pre><code class="python">def create_record_from_row(
     self, row: tuple, parent: bool = True, search_model: bool = True
@@ -1261,7 +1261,7 @@ otherwise</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
-<a href="https://github.com/dtodd-wipeos/xlsx-to-itad-odoo/blob/fdb1682d276e659c77195ec91a12af2c95695046/app.py#L146-L156" class="git-link">Browse git</a>
+<a href="https://github.com/dtodd-wipeos/xlsx-to-itad-odoo/blob/0fb9ed425228ba9ac132fed71442920c50f9bf6a/app.py#L146-L156" class="git-link">Browse git</a>
 </summary>
 <pre><code class="python">def get_id_from_model(self, model: str) -&gt; Union[tuple, None]:
     &#34;&#34;&#34;
@@ -1295,7 +1295,7 @@ select the "correct" database id.</p>
 <details class="source">
 <summary>
 <span>Expand source code</span>
-<a href="https://github.com/dtodd-wipeos/xlsx-to-itad-odoo/blob/fdb1682d276e659c77195ec91a12af2c95695046/app.py#L294-L326" class="git-link">Browse git</a>
+<a href="https://github.com/dtodd-wipeos/xlsx-to-itad-odoo/blob/0fb9ed425228ba9ac132fed71442920c50f9bf6a/app.py#L294-L326" class="git-link">Browse git</a>
 </summary>
 <pre><code class="python">def get_odoo_model_ids(self) -&gt; &#39;ProcessWorkbook&#39;:
     &#34;&#34;&#34;
@@ -1340,7 +1340,7 @@ select the "correct" database id.</p>
 <details class="source">
 <summary>
 <span>Expand source code</span>
-<a href="https://github.com/dtodd-wipeos/xlsx-to-itad-odoo/blob/fdb1682d276e659c77195ec91a12af2c95695046/app.py#L280-L286" class="git-link">Browse git</a>
+<a href="https://github.com/dtodd-wipeos/xlsx-to-itad-odoo/blob/0fb9ed425228ba9ac132fed71442920c50f9bf6a/app.py#L280-L286" class="git-link">Browse git</a>
 </summary>
 <pre><code class="python">def get_records(self) -&gt; &#39;ProcessWorkbook&#39;:
     &#34;&#34;&#34;
@@ -1363,7 +1363,7 @@ rows to an ignore csv</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
-<a href="https://github.com/dtodd-wipeos/xlsx-to-itad-odoo/blob/fdb1682d276e659c77195ec91a12af2c95695046/app.py#L467-L492" class="git-link">Browse git</a>
+<a href="https://github.com/dtodd-wipeos/xlsx-to-itad-odoo/blob/0fb9ed425228ba9ac132fed71442920c50f9bf6a/app.py#L467-L492" class="git-link">Browse git</a>
 </summary>
 <pre><code class="python">def remove_ignored_records(self) -&gt; None:
     &#34;&#34;&#34;
@@ -1401,7 +1401,7 @@ rows to an ignore csv</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
-<a href="https://github.com/dtodd-wipeos/xlsx-to-itad-odoo/blob/fdb1682d276e659c77195ec91a12af2c95695046/app.py#L494-L503" class="git-link">Browse git</a>
+<a href="https://github.com/dtodd-wipeos/xlsx-to-itad-odoo/blob/0fb9ed425228ba9ac132fed71442920c50f9bf6a/app.py#L494-L503" class="git-link">Browse git</a>
 </summary>
 <pre><code class="python">def run(self) -&gt; None:
     &#34;&#34;&#34;
@@ -1434,7 +1434,7 @@ to be created (used to save it to a csv)</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
-<a href="https://github.com/dtodd-wipeos/xlsx-to-itad-odoo/blob/fdb1682d276e659c77195ec91a12af2c95695046/app.py#L158-L182" class="git-link">Browse git</a>
+<a href="https://github.com/dtodd-wipeos/xlsx-to-itad-odoo/blob/0fb9ed425228ba9ac132fed71442920c50f9bf6a/app.py#L158-L182" class="git-link">Browse git</a>
 </summary>
 <pre><code class="python">def serial_in_records(self, serial: str, records: Record = None) -&gt; bool:
     &#34;&#34;&#34;
@@ -1471,7 +1471,7 @@ to be created (used to save it to a csv)</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
-<a href="https://github.com/dtodd-wipeos/xlsx-to-itad-odoo/blob/fdb1682d276e659c77195ec91a12af2c95695046/app.py#L288-L292" class="git-link">Browse git</a>
+<a href="https://github.com/dtodd-wipeos/xlsx-to-itad-odoo/blob/0fb9ed425228ba9ac132fed71442920c50f9bf6a/app.py#L288-L292" class="git-link">Browse git</a>
 </summary>
 <pre><code class="python">def show_records(self) -&gt; None:
     &#34;&#34;&#34;

--- a/html/xlsx-to-itad-odoo/app.html
+++ b/html/xlsx-to-itad-odoo/app.html
@@ -31,6 +31,7 @@ the XMLRPC interface</p>
 <details class="source">
 <summary>
 <span>Expand source code</span>
+<a href="https://github.com/dtodd-wipeos/xlsx-to-itad-odoo/6b5eba7862c8f641ff0f768615c9a69b76ff8430/app.py#L0-L505" class="git-link">Browse git</a>
 </summary>
 <pre><code class="python">#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
@@ -558,6 +559,7 @@ from the workbook and uploading it to Odoo</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
+<a href="https://github.com/dtodd-wipeos/xlsx-to-itad-odoo/6b5eba7862c8f641ff0f768615c9a69b76ff8430/app.py#L74-L503" class="git-link">Browse git</a>
 </summary>
 <pre><code class="python">class ProcessWorkbook:
     &#34;&#34;&#34;
@@ -1005,6 +1007,7 @@ False otherwise.</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
+<a href="https://github.com/dtodd-wipeos/xlsx-to-itad-odoo/6b5eba7862c8f641ff0f768615c9a69b76ff8430/app.py#L350-L372" class="git-link">Browse git</a>
 </summary>
 <pre><code class="python">def asset_line_exists(self, record: Record) -&gt; bool:
     &#34;&#34;&#34;
@@ -1050,6 +1053,7 @@ will still be created, without any Children</p>
 <details class="source">
 <summary>
 <span>Expand source code</span>
+<a href="https://github.com/dtodd-wipeos/xlsx-to-itad-odoo/6b5eba7862c8f641ff0f768615c9a69b76ff8430/app.py#L230-L278" class="git-link">Browse git</a>
 </summary>
 <pre><code class="python">def build_record_list(self) -&gt; &#39;ProcessWorkbook&#39;:
     &#34;&#34;&#34;
@@ -1114,6 +1118,7 @@ data destruction line items.</p>
 <details class="source">
 <summary>
 <span>Expand source code</span>
+<a href="https://github.com/dtodd-wipeos/xlsx-to-itad-odoo/6b5eba7862c8f641ff0f768615c9a69b76ff8430/app.py#L443-L465" class="git-link">Browse git</a>
 </summary>
 <pre><code class="python">def create_line_items(self) -&gt; &#39;ProcessWorkbook&#39;:
     &#34;&#34;&#34;
@@ -1151,6 +1156,7 @@ then store those newly created ids</p>
 <details class="source">
 <summary>
 <span>Expand source code</span>
+<a href="https://github.com/dtodd-wipeos/xlsx-to-itad-odoo/6b5eba7862c8f641ff0f768615c9a69b76ff8430/app.py#L328-L348" class="git-link">Browse git</a>
 </summary>
 <pre><code class="python">def create_missing_model_ids(self) -&gt; &#39;ProcessWorkbook&#39;:
     &#34;&#34;&#34;
@@ -1195,6 +1201,7 @@ created Record object. Otherwise, it returns False</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
+<a href="https://github.com/dtodd-wipeos/xlsx-to-itad-odoo/6b5eba7862c8f641ff0f768615c9a69b76ff8430/app.py#L184-L228" class="git-link">Browse git</a>
 </summary>
 <pre><code class="python">def create_record_from_row(
     self, row: tuple, parent: bool = True, search_model: bool = True
@@ -1254,6 +1261,7 @@ otherwise</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
+<a href="https://github.com/dtodd-wipeos/xlsx-to-itad-odoo/6b5eba7862c8f641ff0f768615c9a69b76ff8430/app.py#L146-L156" class="git-link">Browse git</a>
 </summary>
 <pre><code class="python">def get_id_from_model(self, model: str) -&gt; Union[tuple, None]:
     &#34;&#34;&#34;
@@ -1287,6 +1295,7 @@ select the "correct" database id.</p>
 <details class="source">
 <summary>
 <span>Expand source code</span>
+<a href="https://github.com/dtodd-wipeos/xlsx-to-itad-odoo/6b5eba7862c8f641ff0f768615c9a69b76ff8430/app.py#L294-L326" class="git-link">Browse git</a>
 </summary>
 <pre><code class="python">def get_odoo_model_ids(self) -&gt; &#39;ProcessWorkbook&#39;:
     &#34;&#34;&#34;
@@ -1331,6 +1340,7 @@ select the "correct" database id.</p>
 <details class="source">
 <summary>
 <span>Expand source code</span>
+<a href="https://github.com/dtodd-wipeos/xlsx-to-itad-odoo/6b5eba7862c8f641ff0f768615c9a69b76ff8430/app.py#L280-L286" class="git-link">Browse git</a>
 </summary>
 <pre><code class="python">def get_records(self) -&gt; &#39;ProcessWorkbook&#39;:
     &#34;&#34;&#34;
@@ -1353,6 +1363,7 @@ rows to an ignore csv</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
+<a href="https://github.com/dtodd-wipeos/xlsx-to-itad-odoo/6b5eba7862c8f641ff0f768615c9a69b76ff8430/app.py#L467-L492" class="git-link">Browse git</a>
 </summary>
 <pre><code class="python">def remove_ignored_records(self) -&gt; None:
     &#34;&#34;&#34;
@@ -1390,6 +1401,7 @@ rows to an ignore csv</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
+<a href="https://github.com/dtodd-wipeos/xlsx-to-itad-odoo/6b5eba7862c8f641ff0f768615c9a69b76ff8430/app.py#L494-L503" class="git-link">Browse git</a>
 </summary>
 <pre><code class="python">def run(self) -&gt; None:
     &#34;&#34;&#34;
@@ -1422,6 +1434,7 @@ to be created (used to save it to a csv)</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
+<a href="https://github.com/dtodd-wipeos/xlsx-to-itad-odoo/6b5eba7862c8f641ff0f768615c9a69b76ff8430/app.py#L158-L182" class="git-link">Browse git</a>
 </summary>
 <pre><code class="python">def serial_in_records(self, serial: str, records: Record = None) -&gt; bool:
     &#34;&#34;&#34;
@@ -1458,6 +1471,7 @@ to be created (used to save it to a csv)</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
+<a href="https://github.com/dtodd-wipeos/xlsx-to-itad-odoo/6b5eba7862c8f641ff0f768615c9a69b76ff8430/app.py#L288-L292" class="git-link">Browse git</a>
 </summary>
 <pre><code class="python">def show_records(self) -&gt; None:
     &#34;&#34;&#34;

--- a/html/xlsx-to-itad-odoo/app.html
+++ b/html/xlsx-to-itad-odoo/app.html
@@ -39,6 +39,11 @@ the XMLRPC interface</p>
 # License: MIT License, refer to `license.md` for more information
 
 # pylint: disable=import-error
+# pylint: disable=bad-whitespace
+# pylint: disable=bad-continuation
+# pylint: disable=logging-not-lazy
+# pylint: disable=unnecessary-comprehension
+# pylint: disable=too-many-instance-attributes
 
 &#34;&#34;&#34;
     A Really hacky script (not really), who&#39;s purpose
@@ -53,6 +58,7 @@ import csv
 import time
 import logging
 import itertools
+from typing import Union
 
 from openpyxl import load_workbook
 from record import Record
@@ -105,8 +111,7 @@ class ProcessWorkbook:
         from the workbook and uploading it to Odoo
     &#34;&#34;&#34;
 
-    # pylint: disable=too-many-instance-attributes
-    def __init__(self):
+    def __init__(self) -&gt; None:
         self.api = API()
         self.workbook = load_workbook(filename=SPREADSHEET, data_only=True)[SHEET]
 
@@ -147,7 +152,7 @@ class ProcessWorkbook:
 
         logging.info(&#39;Initialized ProcessWorkbook&#39;)
 
-    def __del__(self):
+    def __del__(self) -&gt; None:
         &#34;&#34;&#34;
             Automatically closes file handlers when destructed normally
         &#34;&#34;&#34;
@@ -160,7 +165,6 @@ class ProcessWorkbook:
         logging.info(&#39;Prevented %d Records from being uploaded&#39;, (self.records_ignored))
 
         for row in self.failed_records:
-            # pylint: disable=logging-not-lazy
             logging.info(
                 &#39;Row that failed Record Creation: %s | %s | %s | %s | %s&#39; % (
                     row[0].value,
@@ -173,7 +177,7 @@ class ProcessWorkbook:
 
         logging.info(&#39;ProcessWorkbook Finished&#39;)
 
-    def get_id_from_model(self, model):
+    def get_id_from_model(self, model: str) -&gt; Union[tuple, None]:
         &#34;&#34;&#34;
             Searches `self.models_to_ids` for
             a matching `model`, and returns the
@@ -185,7 +189,7 @@ class ProcessWorkbook:
                 return item[1]
         return None
 
-    def serial_in_records(self, serial, records=None):
+    def serial_in_records(self, serial: str, records: Record = None) -&gt; bool:
         &#34;&#34;&#34;
             Determines if a particular serial number
             is in a record list, and returns True if so;
@@ -211,7 +215,9 @@ class ProcessWorkbook:
             return True
         return False
 
-    def create_record_from_row(self, row, parent=True, search_model=True):
+    def create_record_from_row(
+        self, row: tuple, parent: bool = True, search_model: bool = True
+    ) -&gt; Union[bool, Record]:
         &#34;&#34;&#34;
             With a provided `row`, this method will first search
             for a matching serial number and if it doesn&#39;t exist,
@@ -233,7 +239,6 @@ class ProcessWorkbook:
 
         serial = str(row[0].value)
         if not self.serial_in_records(serial):
-            # pylint: disable=bad-whitespace
             logging.debug(&#39;Creating Record for %s&#39;, (serial))
             record = Record(
                 serial = serial,
@@ -256,7 +261,7 @@ class ProcessWorkbook:
             return record
         return False
 
-    def build_record_list(self):
+    def build_record_list(self) -&gt; &#39;ProcessWorkbook&#39;:
         &#34;&#34;&#34;
             Reads the workbook and sorts each row into
             multiple instances of the Record class.
@@ -276,7 +281,6 @@ class ProcessWorkbook:
             Returns `self` (this instance of ProcessWorkbook)
         &#34;&#34;&#34;
         logging.info(&#39;Getting rows from the spreadsheet and sorting relationships&#39;)
-        # pylint: disable=bad-continuation
         for row in self.workbook.iter_rows(
             min_row=FIRST_ROW,
             max_col=LAST_COL,
@@ -307,7 +311,7 @@ class ProcessWorkbook:
 
         return self
 
-    def get_records(self):
+    def get_records(self) -&gt; &#39;ProcessWorkbook&#39;:
         &#34;&#34;&#34;
             Deprecated, use `build_record_list` instead.
         &#34;&#34;&#34;
@@ -315,14 +319,13 @@ class ProcessWorkbook:
         logging.warning(&#39;Please use `build_record_list` instead.&#39;)
         return self.build_record_list()
 
-    def show_records(self):
+    def show_records(self) -&gt; None:
         &#34;&#34;&#34;
             Logs all of the records stored, in JSON format
         &#34;&#34;&#34;
-        # pylint: disable=unnecessary-comprehension
         logging.debug([record for record in self.records])
 
-    def get_odoo_model_ids(self):
+    def get_odoo_model_ids(self) -&gt; &#39;ProcessWorkbook&#39;:
         &#34;&#34;&#34;
             Iterates over unique models and searches
             Odoo for the database id of those models.
@@ -356,7 +359,7 @@ class ProcessWorkbook:
                 # models are duplicated (for whatever reason)
                 self.models_to_ids.append((model, odoo_records[0][&#39;id&#39;]))
 
-    def create_missing_model_ids(self):
+    def create_missing_model_ids(self) -&gt; &#39;ProcessWorkbook&#39;:
         &#34;&#34;&#34;
             For any models that couldn&#39;t be located
             when initally searched, create them and
@@ -378,7 +381,7 @@ class ProcessWorkbook:
 
         return self
 
-    def asset_line_exists(self, record):
+    def asset_line_exists(self, record: Record) -&gt; bool:
         &#34;&#34;&#34;
             Searches the asset catalog for
             a line item matching the provided `record`.
@@ -402,7 +405,7 @@ class ProcessWorkbook:
             return True
         return False
 
-    def _create_asset_catalog_line(self, record):
+    def _create_asset_catalog_line(self, record: Record) -&gt; &#39;ProcessWorkbook&#39;:
         &#34;&#34;&#34;
             With the provided `record` (Record) instance,
             this method will issue an API request to Odoo
@@ -429,7 +432,9 @@ class ProcessWorkbook:
 
         return self
 
-    def _create_data_destruction_line(self, record, child=False):
+    def _create_data_destruction_line(
+        self, record: Record, child: bool = False
+    ) -&gt; &#39;ProcessWorkbook&#39;:
         &#34;&#34;&#34;
             With the provided `record` and optional `child` Record
             instances, this method will issue an API request to
@@ -469,7 +474,7 @@ class ProcessWorkbook:
 
         return self
 
-    def create_line_items(self):
+    def create_line_items(self) -&gt; &#39;ProcessWorkbook&#39;:
         &#34;&#34;&#34;
             For all the records that we can
             process (there&#39;s a mapped model),
@@ -493,7 +498,7 @@ class ProcessWorkbook:
 
         return self
 
-    def remove_ignored_records(self):
+    def remove_ignored_records(self) -&gt; None:
         &#34;&#34;&#34;
             Populates `self.records_to_upload` with
             any record that is not also a part of the
@@ -520,7 +525,7 @@ class ProcessWorkbook:
             else:
                 self.records_to_upload.append(record)
 
-    def run(self):
+    def run(self) -&gt; None:
         &#34;&#34;&#34;
             Runs everything in the order that is required
         &#34;&#34;&#34;
@@ -560,8 +565,7 @@ from the workbook and uploading it to Odoo</p></div>
         from the workbook and uploading it to Odoo
     &#34;&#34;&#34;
 
-    # pylint: disable=too-many-instance-attributes
-    def __init__(self):
+    def __init__(self) -&gt; None:
         self.api = API()
         self.workbook = load_workbook(filename=SPREADSHEET, data_only=True)[SHEET]
 
@@ -602,7 +606,7 @@ from the workbook and uploading it to Odoo</p></div>
 
         logging.info(&#39;Initialized ProcessWorkbook&#39;)
 
-    def __del__(self):
+    def __del__(self) -&gt; None:
         &#34;&#34;&#34;
             Automatically closes file handlers when destructed normally
         &#34;&#34;&#34;
@@ -615,7 +619,6 @@ from the workbook and uploading it to Odoo</p></div>
         logging.info(&#39;Prevented %d Records from being uploaded&#39;, (self.records_ignored))
 
         for row in self.failed_records:
-            # pylint: disable=logging-not-lazy
             logging.info(
                 &#39;Row that failed Record Creation: %s | %s | %s | %s | %s&#39; % (
                     row[0].value,
@@ -628,7 +631,7 @@ from the workbook and uploading it to Odoo</p></div>
 
         logging.info(&#39;ProcessWorkbook Finished&#39;)
 
-    def get_id_from_model(self, model):
+    def get_id_from_model(self, model: str) -&gt; Union[tuple, None]:
         &#34;&#34;&#34;
             Searches `self.models_to_ids` for
             a matching `model`, and returns the
@@ -640,7 +643,7 @@ from the workbook and uploading it to Odoo</p></div>
                 return item[1]
         return None
 
-    def serial_in_records(self, serial, records=None):
+    def serial_in_records(self, serial: str, records: Record = None) -&gt; bool:
         &#34;&#34;&#34;
             Determines if a particular serial number
             is in a record list, and returns True if so;
@@ -666,7 +669,9 @@ from the workbook and uploading it to Odoo</p></div>
             return True
         return False
 
-    def create_record_from_row(self, row, parent=True, search_model=True):
+    def create_record_from_row(
+        self, row: tuple, parent: bool = True, search_model: bool = True
+    ) -&gt; Union[bool, Record]:
         &#34;&#34;&#34;
             With a provided `row`, this method will first search
             for a matching serial number and if it doesn&#39;t exist,
@@ -688,7 +693,6 @@ from the workbook and uploading it to Odoo</p></div>
 
         serial = str(row[0].value)
         if not self.serial_in_records(serial):
-            # pylint: disable=bad-whitespace
             logging.debug(&#39;Creating Record for %s&#39;, (serial))
             record = Record(
                 serial = serial,
@@ -711,7 +715,7 @@ from the workbook and uploading it to Odoo</p></div>
             return record
         return False
 
-    def build_record_list(self):
+    def build_record_list(self) -&gt; &#39;ProcessWorkbook&#39;:
         &#34;&#34;&#34;
             Reads the workbook and sorts each row into
             multiple instances of the Record class.
@@ -731,7 +735,6 @@ from the workbook and uploading it to Odoo</p></div>
             Returns `self` (this instance of ProcessWorkbook)
         &#34;&#34;&#34;
         logging.info(&#39;Getting rows from the spreadsheet and sorting relationships&#39;)
-        # pylint: disable=bad-continuation
         for row in self.workbook.iter_rows(
             min_row=FIRST_ROW,
             max_col=LAST_COL,
@@ -762,7 +765,7 @@ from the workbook and uploading it to Odoo</p></div>
 
         return self
 
-    def get_records(self):
+    def get_records(self) -&gt; &#39;ProcessWorkbook&#39;:
         &#34;&#34;&#34;
             Deprecated, use `build_record_list` instead.
         &#34;&#34;&#34;
@@ -770,14 +773,13 @@ from the workbook and uploading it to Odoo</p></div>
         logging.warning(&#39;Please use `build_record_list` instead.&#39;)
         return self.build_record_list()
 
-    def show_records(self):
+    def show_records(self) -&gt; None:
         &#34;&#34;&#34;
             Logs all of the records stored, in JSON format
         &#34;&#34;&#34;
-        # pylint: disable=unnecessary-comprehension
         logging.debug([record for record in self.records])
 
-    def get_odoo_model_ids(self):
+    def get_odoo_model_ids(self) -&gt; &#39;ProcessWorkbook&#39;:
         &#34;&#34;&#34;
             Iterates over unique models and searches
             Odoo for the database id of those models.
@@ -811,7 +813,7 @@ from the workbook and uploading it to Odoo</p></div>
                 # models are duplicated (for whatever reason)
                 self.models_to_ids.append((model, odoo_records[0][&#39;id&#39;]))
 
-    def create_missing_model_ids(self):
+    def create_missing_model_ids(self) -&gt; &#39;ProcessWorkbook&#39;:
         &#34;&#34;&#34;
             For any models that couldn&#39;t be located
             when initally searched, create them and
@@ -833,7 +835,7 @@ from the workbook and uploading it to Odoo</p></div>
 
         return self
 
-    def asset_line_exists(self, record):
+    def asset_line_exists(self, record: Record) -&gt; bool:
         &#34;&#34;&#34;
             Searches the asset catalog for
             a line item matching the provided `record`.
@@ -857,7 +859,7 @@ from the workbook and uploading it to Odoo</p></div>
             return True
         return False
 
-    def _create_asset_catalog_line(self, record):
+    def _create_asset_catalog_line(self, record: Record) -&gt; &#39;ProcessWorkbook&#39;:
         &#34;&#34;&#34;
             With the provided `record` (Record) instance,
             this method will issue an API request to Odoo
@@ -884,7 +886,9 @@ from the workbook and uploading it to Odoo</p></div>
 
         return self
 
-    def _create_data_destruction_line(self, record, child=False):
+    def _create_data_destruction_line(
+        self, record: Record, child: bool = False
+    ) -&gt; &#39;ProcessWorkbook&#39;:
         &#34;&#34;&#34;
             With the provided `record` and optional `child` Record
             instances, this method will issue an API request to
@@ -924,7 +928,7 @@ from the workbook and uploading it to Odoo</p></div>
 
         return self
 
-    def create_line_items(self):
+    def create_line_items(self) -&gt; &#39;ProcessWorkbook&#39;:
         &#34;&#34;&#34;
             For all the records that we can
             process (there&#39;s a mapped model),
@@ -948,7 +952,7 @@ from the workbook and uploading it to Odoo</p></div>
 
         return self
 
-    def remove_ignored_records(self):
+    def remove_ignored_records(self) -&gt; None:
         &#34;&#34;&#34;
             Populates `self.records_to_upload` with
             any record that is not also a part of the
@@ -975,7 +979,7 @@ from the workbook and uploading it to Odoo</p></div>
             else:
                 self.records_to_upload.append(record)
 
-    def run(self):
+    def run(self) -&gt; None:
         &#34;&#34;&#34;
             Runs everything in the order that is required
         &#34;&#34;&#34;
@@ -989,7 +993,7 @@ from the workbook and uploading it to Odoo</p></div>
 <h3>Methods</h3>
 <dl>
 <dt id="xlsx-to-itad-odoo.app.ProcessWorkbook.asset_line_exists"><code class="name flex">
-<span>def <span class="ident">asset_line_exists</span></span>(<span>self, record)</span>
+<span>def <span class="ident">asset_line_exists</span></span>(<span>self, record: record.Record) -> bool</span>
 </code></dt>
 <dd>
 <div class="desc"><p>Searches the asset catalog for
@@ -1002,7 +1006,7 @@ False otherwise.</p></div>
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">def asset_line_exists(self, record):
+<pre><code class="python">def asset_line_exists(self, record: Record) -&gt; bool:
     &#34;&#34;&#34;
         Searches the asset catalog for
         a line item matching the provided `record`.
@@ -1028,7 +1032,7 @@ False otherwise.</p></div>
 </details>
 </dd>
 <dt id="xlsx-to-itad-odoo.app.ProcessWorkbook.build_record_list"><code class="name flex">
-<span>def <span class="ident">build_record_list</span></span>(<span>self)</span>
+<span>def <span class="ident">build_record_list</span></span>(<span>self) -> xlsx-to-itad-odoo.app.ProcessWorkbook</span>
 </code></dt>
 <dd>
 <div class="desc"><p>Reads the workbook and sorts each row into
@@ -1047,7 +1051,7 @@ will still be created, without any Children</p>
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">def build_record_list(self):
+<pre><code class="python">def build_record_list(self) -&gt; &#39;ProcessWorkbook&#39;:
     &#34;&#34;&#34;
         Reads the workbook and sorts each row into
         multiple instances of the Record class.
@@ -1067,7 +1071,6 @@ will still be created, without any Children</p>
         Returns `self` (this instance of ProcessWorkbook)
     &#34;&#34;&#34;
     logging.info(&#39;Getting rows from the spreadsheet and sorting relationships&#39;)
-    # pylint: disable=bad-continuation
     for row in self.workbook.iter_rows(
         min_row=FIRST_ROW,
         max_col=LAST_COL,
@@ -1100,7 +1103,7 @@ will still be created, without any Children</p>
 </details>
 </dd>
 <dt id="xlsx-to-itad-odoo.app.ProcessWorkbook.create_line_items"><code class="name flex">
-<span>def <span class="ident">create_line_items</span></span>(<span>self)</span>
+<span>def <span class="ident">create_line_items</span></span>(<span>self) -> xlsx-to-itad-odoo.app.ProcessWorkbook</span>
 </code></dt>
 <dd>
 <div class="desc"><p>For all the records that we can
@@ -1112,7 +1115,7 @@ data destruction line items.</p>
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">def create_line_items(self):
+<pre><code class="python">def create_line_items(self) -&gt; &#39;ProcessWorkbook&#39;:
     &#34;&#34;&#34;
         For all the records that we can
         process (there&#39;s a mapped model),
@@ -1138,7 +1141,7 @@ data destruction line items.</p>
 </details>
 </dd>
 <dt id="xlsx-to-itad-odoo.app.ProcessWorkbook.create_missing_model_ids"><code class="name flex">
-<span>def <span class="ident">create_missing_model_ids</span></span>(<span>self)</span>
+<span>def <span class="ident">create_missing_model_ids</span></span>(<span>self) -> xlsx-to-itad-odoo.app.ProcessWorkbook</span>
 </code></dt>
 <dd>
 <div class="desc"><p>For any models that couldn't be located
@@ -1149,7 +1152,7 @@ then store those newly created ids</p>
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">def create_missing_model_ids(self):
+<pre><code class="python">def create_missing_model_ids(self) -&gt; &#39;ProcessWorkbook&#39;:
     &#34;&#34;&#34;
         For any models that couldn&#39;t be located
         when initally searched, create them and
@@ -1173,7 +1176,7 @@ then store those newly created ids</p>
 </details>
 </dd>
 <dt id="xlsx-to-itad-odoo.app.ProcessWorkbook.create_record_from_row"><code class="name flex">
-<span>def <span class="ident">create_record_from_row</span></span>(<span>self, row, parent=True, search_model=True)</span>
+<span>def <span class="ident">create_record_from_row</span></span>(<span>self, row: tuple, parent: bool = True, search_model: bool = True) -> Union[bool, record.Record]</span>
 </code></dt>
 <dd>
 <div class="desc"><p>With a provided <code>row</code>, this method will first search
@@ -1193,7 +1196,9 @@ created Record object. Otherwise, it returns False</p></div>
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">def create_record_from_row(self, row, parent=True, search_model=True):
+<pre><code class="python">def create_record_from_row(
+    self, row: tuple, parent: bool = True, search_model: bool = True
+) -&gt; Union[bool, Record]:
     &#34;&#34;&#34;
         With a provided `row`, this method will first search
         for a matching serial number and if it doesn&#39;t exist,
@@ -1215,7 +1220,6 @@ created Record object. Otherwise, it returns False</p></div>
 
     serial = str(row[0].value)
     if not self.serial_in_records(serial):
-        # pylint: disable=bad-whitespace
         logging.debug(&#39;Creating Record for %s&#39;, (serial))
         record = Record(
             serial = serial,
@@ -1240,7 +1244,7 @@ created Record object. Otherwise, it returns False</p></div>
 </details>
 </dd>
 <dt id="xlsx-to-itad-odoo.app.ProcessWorkbook.get_id_from_model"><code class="name flex">
-<span>def <span class="ident">get_id_from_model</span></span>(<span>self, model)</span>
+<span>def <span class="ident">get_id_from_model</span></span>(<span>self, model: str) -> Union[tuple, NoneType]</span>
 </code></dt>
 <dd>
 <div class="desc"><p>Searches <code>self.models_to_ids</code> for
@@ -1251,7 +1255,7 @@ otherwise</p></div>
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">def get_id_from_model(self, model):
+<pre><code class="python">def get_id_from_model(self, model: str) -&gt; Union[tuple, None]:
     &#34;&#34;&#34;
         Searches `self.models_to_ids` for
         a matching `model`, and returns the
@@ -1265,7 +1269,7 @@ otherwise</p></div>
 </details>
 </dd>
 <dt id="xlsx-to-itad-odoo.app.ProcessWorkbook.get_odoo_model_ids"><code class="name flex">
-<span>def <span class="ident">get_odoo_model_ids</span></span>(<span>self)</span>
+<span>def <span class="ident">get_odoo_model_ids</span></span>(<span>self) -> xlsx-to-itad-odoo.app.ProcessWorkbook</span>
 </code></dt>
 <dd>
 <div class="desc"><p>Iterates over unique models and searches
@@ -1284,7 +1288,7 @@ select the "correct" database id.</p>
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">def get_odoo_model_ids(self):
+<pre><code class="python">def get_odoo_model_ids(self) -&gt; &#39;ProcessWorkbook&#39;:
     &#34;&#34;&#34;
         Iterates over unique models and searches
         Odoo for the database id of those models.
@@ -1320,7 +1324,7 @@ select the "correct" database id.</p>
 </details>
 </dd>
 <dt id="xlsx-to-itad-odoo.app.ProcessWorkbook.get_records"><code class="name flex">
-<span>def <span class="ident">get_records</span></span>(<span>self)</span>
+<span>def <span class="ident">get_records</span></span>(<span>self) -> xlsx-to-itad-odoo.app.ProcessWorkbook</span>
 </code></dt>
 <dd>
 <div class="desc"><p>Deprecated, use <code>build_record_list</code> instead.</p></div>
@@ -1328,7 +1332,7 @@ select the "correct" database id.</p>
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">def get_records(self):
+<pre><code class="python">def get_records(self) -&gt; &#39;ProcessWorkbook&#39;:
     &#34;&#34;&#34;
         Deprecated, use `build_record_list` instead.
     &#34;&#34;&#34;
@@ -1338,7 +1342,7 @@ select the "correct" database id.</p>
 </details>
 </dd>
 <dt id="xlsx-to-itad-odoo.app.ProcessWorkbook.remove_ignored_records"><code class="name flex">
-<span>def <span class="ident">remove_ignored_records</span></span>(<span>self)</span>
+<span>def <span class="ident">remove_ignored_records</span></span>(<span>self) -> NoneType</span>
 </code></dt>
 <dd>
 <div class="desc"><p>Populates <code>self.records_to_upload</code> with
@@ -1350,7 +1354,7 @@ rows to an ignore csv</p></div>
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">def remove_ignored_records(self):
+<pre><code class="python">def remove_ignored_records(self) -&gt; None:
     &#34;&#34;&#34;
         Populates `self.records_to_upload` with
         any record that is not also a part of the
@@ -1379,7 +1383,7 @@ rows to an ignore csv</p></div>
 </details>
 </dd>
 <dt id="xlsx-to-itad-odoo.app.ProcessWorkbook.run"><code class="name flex">
-<span>def <span class="ident">run</span></span>(<span>self)</span>
+<span>def <span class="ident">run</span></span>(<span>self) -> NoneType</span>
 </code></dt>
 <dd>
 <div class="desc"><p>Runs everything in the order that is required</p></div>
@@ -1387,7 +1391,7 @@ rows to an ignore csv</p></div>
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">def run(self):
+<pre><code class="python">def run(self) -&gt; None:
     &#34;&#34;&#34;
         Runs everything in the order that is required
     &#34;&#34;&#34;
@@ -1400,7 +1404,7 @@ rows to an ignore csv</p></div>
 </details>
 </dd>
 <dt id="xlsx-to-itad-odoo.app.ProcessWorkbook.serial_in_records"><code class="name flex">
-<span>def <span class="ident">serial_in_records</span></span>(<span>self, serial, records=None)</span>
+<span>def <span class="ident">serial_in_records</span></span>(<span>self, serial: str, records: record.Record = None) -> bool</span>
 </code></dt>
 <dd>
 <div class="desc"><p>Determines if a particular serial number
@@ -1419,7 +1423,7 @@ to be created (used to save it to a csv)</p></div>
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">def serial_in_records(self, serial, records=None):
+<pre><code class="python">def serial_in_records(self, serial: str, records: Record = None) -&gt; bool:
     &#34;&#34;&#34;
         Determines if a particular serial number
         is in a record list, and returns True if so;
@@ -1447,7 +1451,7 @@ to be created (used to save it to a csv)</p></div>
 </details>
 </dd>
 <dt id="xlsx-to-itad-odoo.app.ProcessWorkbook.show_records"><code class="name flex">
-<span>def <span class="ident">show_records</span></span>(<span>self)</span>
+<span>def <span class="ident">show_records</span></span>(<span>self) -> NoneType</span>
 </code></dt>
 <dd>
 <div class="desc"><p>Logs all of the records stored, in JSON format</p></div>
@@ -1455,11 +1459,10 @@ to be created (used to save it to a csv)</p></div>
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">def show_records(self):
+<pre><code class="python">def show_records(self) -&gt; None:
     &#34;&#34;&#34;
         Logs all of the records stored, in JSON format
     &#34;&#34;&#34;
-    # pylint: disable=unnecessary-comprehension
     logging.debug([record for record in self.records])</code></pre>
 </details>
 </dd>

--- a/html/xlsx-to-itad-odoo/app.html
+++ b/html/xlsx-to-itad-odoo/app.html
@@ -31,7 +31,7 @@ the XMLRPC interface</p>
 <details class="source">
 <summary>
 <span>Expand source code</span>
-<a href="https://github.com/dtodd-wipeos/xlsx-to-itad-odoo/6b5eba7862c8f641ff0f768615c9a69b76ff8430/app.py#L0-L505" class="git-link">Browse git</a>
+<a href="https://github.com/dtodd-wipeos/xlsx-to-itad-odoo/blob/fdb1682d276e659c77195ec91a12af2c95695046/app.py#L0-L505" class="git-link">Browse git</a>
 </summary>
 <pre><code class="python">#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
@@ -559,7 +559,7 @@ from the workbook and uploading it to Odoo</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
-<a href="https://github.com/dtodd-wipeos/xlsx-to-itad-odoo/6b5eba7862c8f641ff0f768615c9a69b76ff8430/app.py#L74-L503" class="git-link">Browse git</a>
+<a href="https://github.com/dtodd-wipeos/xlsx-to-itad-odoo/blob/fdb1682d276e659c77195ec91a12af2c95695046/app.py#L74-L503" class="git-link">Browse git</a>
 </summary>
 <pre><code class="python">class ProcessWorkbook:
     &#34;&#34;&#34;
@@ -1007,7 +1007,7 @@ False otherwise.</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
-<a href="https://github.com/dtodd-wipeos/xlsx-to-itad-odoo/6b5eba7862c8f641ff0f768615c9a69b76ff8430/app.py#L350-L372" class="git-link">Browse git</a>
+<a href="https://github.com/dtodd-wipeos/xlsx-to-itad-odoo/blob/fdb1682d276e659c77195ec91a12af2c95695046/app.py#L350-L372" class="git-link">Browse git</a>
 </summary>
 <pre><code class="python">def asset_line_exists(self, record: Record) -&gt; bool:
     &#34;&#34;&#34;
@@ -1053,7 +1053,7 @@ will still be created, without any Children</p>
 <details class="source">
 <summary>
 <span>Expand source code</span>
-<a href="https://github.com/dtodd-wipeos/xlsx-to-itad-odoo/6b5eba7862c8f641ff0f768615c9a69b76ff8430/app.py#L230-L278" class="git-link">Browse git</a>
+<a href="https://github.com/dtodd-wipeos/xlsx-to-itad-odoo/blob/fdb1682d276e659c77195ec91a12af2c95695046/app.py#L230-L278" class="git-link">Browse git</a>
 </summary>
 <pre><code class="python">def build_record_list(self) -&gt; &#39;ProcessWorkbook&#39;:
     &#34;&#34;&#34;
@@ -1118,7 +1118,7 @@ data destruction line items.</p>
 <details class="source">
 <summary>
 <span>Expand source code</span>
-<a href="https://github.com/dtodd-wipeos/xlsx-to-itad-odoo/6b5eba7862c8f641ff0f768615c9a69b76ff8430/app.py#L443-L465" class="git-link">Browse git</a>
+<a href="https://github.com/dtodd-wipeos/xlsx-to-itad-odoo/blob/fdb1682d276e659c77195ec91a12af2c95695046/app.py#L443-L465" class="git-link">Browse git</a>
 </summary>
 <pre><code class="python">def create_line_items(self) -&gt; &#39;ProcessWorkbook&#39;:
     &#34;&#34;&#34;
@@ -1156,7 +1156,7 @@ then store those newly created ids</p>
 <details class="source">
 <summary>
 <span>Expand source code</span>
-<a href="https://github.com/dtodd-wipeos/xlsx-to-itad-odoo/6b5eba7862c8f641ff0f768615c9a69b76ff8430/app.py#L328-L348" class="git-link">Browse git</a>
+<a href="https://github.com/dtodd-wipeos/xlsx-to-itad-odoo/blob/fdb1682d276e659c77195ec91a12af2c95695046/app.py#L328-L348" class="git-link">Browse git</a>
 </summary>
 <pre><code class="python">def create_missing_model_ids(self) -&gt; &#39;ProcessWorkbook&#39;:
     &#34;&#34;&#34;
@@ -1201,7 +1201,7 @@ created Record object. Otherwise, it returns False</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
-<a href="https://github.com/dtodd-wipeos/xlsx-to-itad-odoo/6b5eba7862c8f641ff0f768615c9a69b76ff8430/app.py#L184-L228" class="git-link">Browse git</a>
+<a href="https://github.com/dtodd-wipeos/xlsx-to-itad-odoo/blob/fdb1682d276e659c77195ec91a12af2c95695046/app.py#L184-L228" class="git-link">Browse git</a>
 </summary>
 <pre><code class="python">def create_record_from_row(
     self, row: tuple, parent: bool = True, search_model: bool = True
@@ -1261,7 +1261,7 @@ otherwise</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
-<a href="https://github.com/dtodd-wipeos/xlsx-to-itad-odoo/6b5eba7862c8f641ff0f768615c9a69b76ff8430/app.py#L146-L156" class="git-link">Browse git</a>
+<a href="https://github.com/dtodd-wipeos/xlsx-to-itad-odoo/blob/fdb1682d276e659c77195ec91a12af2c95695046/app.py#L146-L156" class="git-link">Browse git</a>
 </summary>
 <pre><code class="python">def get_id_from_model(self, model: str) -&gt; Union[tuple, None]:
     &#34;&#34;&#34;
@@ -1295,7 +1295,7 @@ select the "correct" database id.</p>
 <details class="source">
 <summary>
 <span>Expand source code</span>
-<a href="https://github.com/dtodd-wipeos/xlsx-to-itad-odoo/6b5eba7862c8f641ff0f768615c9a69b76ff8430/app.py#L294-L326" class="git-link">Browse git</a>
+<a href="https://github.com/dtodd-wipeos/xlsx-to-itad-odoo/blob/fdb1682d276e659c77195ec91a12af2c95695046/app.py#L294-L326" class="git-link">Browse git</a>
 </summary>
 <pre><code class="python">def get_odoo_model_ids(self) -&gt; &#39;ProcessWorkbook&#39;:
     &#34;&#34;&#34;
@@ -1340,7 +1340,7 @@ select the "correct" database id.</p>
 <details class="source">
 <summary>
 <span>Expand source code</span>
-<a href="https://github.com/dtodd-wipeos/xlsx-to-itad-odoo/6b5eba7862c8f641ff0f768615c9a69b76ff8430/app.py#L280-L286" class="git-link">Browse git</a>
+<a href="https://github.com/dtodd-wipeos/xlsx-to-itad-odoo/blob/fdb1682d276e659c77195ec91a12af2c95695046/app.py#L280-L286" class="git-link">Browse git</a>
 </summary>
 <pre><code class="python">def get_records(self) -&gt; &#39;ProcessWorkbook&#39;:
     &#34;&#34;&#34;
@@ -1363,7 +1363,7 @@ rows to an ignore csv</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
-<a href="https://github.com/dtodd-wipeos/xlsx-to-itad-odoo/6b5eba7862c8f641ff0f768615c9a69b76ff8430/app.py#L467-L492" class="git-link">Browse git</a>
+<a href="https://github.com/dtodd-wipeos/xlsx-to-itad-odoo/blob/fdb1682d276e659c77195ec91a12af2c95695046/app.py#L467-L492" class="git-link">Browse git</a>
 </summary>
 <pre><code class="python">def remove_ignored_records(self) -&gt; None:
     &#34;&#34;&#34;
@@ -1401,7 +1401,7 @@ rows to an ignore csv</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
-<a href="https://github.com/dtodd-wipeos/xlsx-to-itad-odoo/6b5eba7862c8f641ff0f768615c9a69b76ff8430/app.py#L494-L503" class="git-link">Browse git</a>
+<a href="https://github.com/dtodd-wipeos/xlsx-to-itad-odoo/blob/fdb1682d276e659c77195ec91a12af2c95695046/app.py#L494-L503" class="git-link">Browse git</a>
 </summary>
 <pre><code class="python">def run(self) -&gt; None:
     &#34;&#34;&#34;
@@ -1434,7 +1434,7 @@ to be created (used to save it to a csv)</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
-<a href="https://github.com/dtodd-wipeos/xlsx-to-itad-odoo/6b5eba7862c8f641ff0f768615c9a69b76ff8430/app.py#L158-L182" class="git-link">Browse git</a>
+<a href="https://github.com/dtodd-wipeos/xlsx-to-itad-odoo/blob/fdb1682d276e659c77195ec91a12af2c95695046/app.py#L158-L182" class="git-link">Browse git</a>
 </summary>
 <pre><code class="python">def serial_in_records(self, serial: str, records: Record = None) -&gt; bool:
     &#34;&#34;&#34;
@@ -1471,7 +1471,7 @@ to be created (used to save it to a csv)</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
-<a href="https://github.com/dtodd-wipeos/xlsx-to-itad-odoo/6b5eba7862c8f641ff0f768615c9a69b76ff8430/app.py#L288-L292" class="git-link">Browse git</a>
+<a href="https://github.com/dtodd-wipeos/xlsx-to-itad-odoo/blob/fdb1682d276e659c77195ec91a12af2c95695046/app.py#L288-L292" class="git-link">Browse git</a>
 </summary>
 <pre><code class="python">def show_records(self) -&gt; None:
     &#34;&#34;&#34;

--- a/html/xlsx-to-itad-odoo/exceptions.html
+++ b/html/xlsx-to-itad-odoo/exceptions.html
@@ -42,7 +42,7 @@ class InputError(Exception):
                 for how to fix it
     &#34;&#34;&#34;
 
-    def __init__(self, field, message):
+    def __init__(self, field: str, message: str) -&gt; Exception:
         self.field = field
         self.message = message</code></pre>
 </details>
@@ -58,7 +58,7 @@ class InputError(Exception):
 <dl>
 <dt id="xlsx-to-itad-odoo.exceptions.InputError"><code class="flex name class">
 <span>class <span class="ident">InputError</span></span>
-<span>(</span><span>field, message)</span>
+<span>(</span><span>field: str, message: str)</span>
 </code></dt>
 <dd>
 <div class="desc"><p>Raises an exception when some input value is not correct.</p>
@@ -79,7 +79,7 @@ for how to fix it</p></div>
                 for how to fix it
     &#34;&#34;&#34;
 
-    def __init__(self, field, message):
+    def __init__(self, field: str, message: str) -&gt; Exception:
         self.field = field
         self.message = message</code></pre>
 </details>

--- a/html/xlsx-to-itad-odoo/exceptions.html
+++ b/html/xlsx-to-itad-odoo/exceptions.html
@@ -23,7 +23,7 @@
 <details class="source">
 <summary>
 <span>Expand source code</span>
-<a href="https://github.com/dtodd-wipeos/xlsx-to-itad-odoo/6b5eba7862c8f641ff0f768615c9a69b76ff8430/exceptions.py#L0-L20" class="git-link">Browse git</a>
+<a href="https://github.com/dtodd-wipeos/xlsx-to-itad-odoo/blob/fdb1682d276e659c77195ec91a12af2c95695046/exceptions.py#L0-L20" class="git-link">Browse git</a>
 </summary>
 <pre><code class="python">#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
@@ -70,7 +70,7 @@ for how to fix it</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
-<a href="https://github.com/dtodd-wipeos/xlsx-to-itad-odoo/6b5eba7862c8f641ff0f768615c9a69b76ff8430/exceptions.py#L10-L21" class="git-link">Browse git</a>
+<a href="https://github.com/dtodd-wipeos/xlsx-to-itad-odoo/blob/fdb1682d276e659c77195ec91a12af2c95695046/exceptions.py#L10-L21" class="git-link">Browse git</a>
 </summary>
 <pre><code class="python">class InputError(Exception):
     &#34;&#34;&#34;

--- a/html/xlsx-to-itad-odoo/exceptions.html
+++ b/html/xlsx-to-itad-odoo/exceptions.html
@@ -23,6 +23,7 @@
 <details class="source">
 <summary>
 <span>Expand source code</span>
+<a href="https://github.com/dtodd-wipeos/xlsx-to-itad-odoo/6b5eba7862c8f641ff0f768615c9a69b76ff8430/exceptions.py#L0-L20" class="git-link">Browse git</a>
 </summary>
 <pre><code class="python">#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
@@ -69,6 +70,7 @@ for how to fix it</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
+<a href="https://github.com/dtodd-wipeos/xlsx-to-itad-odoo/6b5eba7862c8f641ff0f768615c9a69b76ff8430/exceptions.py#L10-L21" class="git-link">Browse git</a>
 </summary>
 <pre><code class="python">class InputError(Exception):
     &#34;&#34;&#34;

--- a/html/xlsx-to-itad-odoo/exceptions.html
+++ b/html/xlsx-to-itad-odoo/exceptions.html
@@ -23,7 +23,7 @@
 <details class="source">
 <summary>
 <span>Expand source code</span>
-<a href="https://github.com/dtodd-wipeos/xlsx-to-itad-odoo/blob/fdb1682d276e659c77195ec91a12af2c95695046/exceptions.py#L0-L20" class="git-link">Browse git</a>
+<a href="https://github.com/dtodd-wipeos/xlsx-to-itad-odoo/blob/0fb9ed425228ba9ac132fed71442920c50f9bf6a/exceptions.py#L0-L20" class="git-link">Browse git</a>
 </summary>
 <pre><code class="python">#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
@@ -70,7 +70,7 @@ for how to fix it</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
-<a href="https://github.com/dtodd-wipeos/xlsx-to-itad-odoo/blob/fdb1682d276e659c77195ec91a12af2c95695046/exceptions.py#L10-L21" class="git-link">Browse git</a>
+<a href="https://github.com/dtodd-wipeos/xlsx-to-itad-odoo/blob/0fb9ed425228ba9ac132fed71442920c50f9bf6a/exceptions.py#L10-L21" class="git-link">Browse git</a>
 </summary>
 <pre><code class="python">class InputError(Exception):
     &#34;&#34;&#34;

--- a/html/xlsx-to-itad-odoo/record.html
+++ b/html/xlsx-to-itad-odoo/record.html
@@ -28,7 +28,7 @@ of importing line items.</p>
 <details class="source">
 <summary>
 <span>Expand source code</span>
-<a href="https://github.com/dtodd-wipeos/xlsx-to-itad-odoo/6b5eba7862c8f641ff0f768615c9a69b76ff8430/record.py#L0-L67" class="git-link">Browse git</a>
+<a href="https://github.com/dtodd-wipeos/xlsx-to-itad-odoo/blob/fdb1682d276e659c77195ec91a12af2c95695046/record.py#L0-L67" class="git-link">Browse git</a>
 </summary>
 <pre><code class="python">#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
@@ -123,7 +123,7 @@ one or more Record objects, or None</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
-<a href="https://github.com/dtodd-wipeos/xlsx-to-itad-odoo/6b5eba7862c8f641ff0f768615c9a69b76ff8430/record.py#L15-L68" class="git-link">Browse git</a>
+<a href="https://github.com/dtodd-wipeos/xlsx-to-itad-odoo/blob/fdb1682d276e659c77195ec91a12af2c95695046/record.py#L15-L68" class="git-link">Browse git</a>
 </summary>
 <pre><code class="python">class Record:
     &#34;&#34;&#34;

--- a/html/xlsx-to-itad-odoo/record.html
+++ b/html/xlsx-to-itad-odoo/record.html
@@ -28,7 +28,7 @@ of importing line items.</p>
 <details class="source">
 <summary>
 <span>Expand source code</span>
-<a href="https://github.com/dtodd-wipeos/xlsx-to-itad-odoo/blob/fdb1682d276e659c77195ec91a12af2c95695046/record.py#L0-L67" class="git-link">Browse git</a>
+<a href="https://github.com/dtodd-wipeos/xlsx-to-itad-odoo/blob/0fb9ed425228ba9ac132fed71442920c50f9bf6a/record.py#L0-L67" class="git-link">Browse git</a>
 </summary>
 <pre><code class="python">#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
@@ -123,7 +123,7 @@ one or more Record objects, or None</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
-<a href="https://github.com/dtodd-wipeos/xlsx-to-itad-odoo/blob/fdb1682d276e659c77195ec91a12af2c95695046/record.py#L15-L68" class="git-link">Browse git</a>
+<a href="https://github.com/dtodd-wipeos/xlsx-to-itad-odoo/blob/0fb9ed425228ba9ac132fed71442920c50f9bf6a/record.py#L15-L68" class="git-link">Browse git</a>
 </summary>
 <pre><code class="python">class Record:
     &#34;&#34;&#34;

--- a/html/xlsx-to-itad-odoo/record.html
+++ b/html/xlsx-to-itad-odoo/record.html
@@ -28,6 +28,7 @@ of importing line items.</p>
 <details class="source">
 <summary>
 <span>Expand source code</span>
+<a href="https://github.com/dtodd-wipeos/xlsx-to-itad-odoo/6b5eba7862c8f641ff0f768615c9a69b76ff8430/record.py#L0-L67" class="git-link">Browse git</a>
 </summary>
 <pre><code class="python">#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
@@ -122,6 +123,7 @@ one or more Record objects, or None</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
+<a href="https://github.com/dtodd-wipeos/xlsx-to-itad-odoo/6b5eba7862c8f641ff0f768615c9a69b76ff8430/record.py#L15-L68" class="git-link">Browse git</a>
 </summary>
 <pre><code class="python">class Record:
     &#34;&#34;&#34;

--- a/html/xlsx-to-itad-odoo/record.html
+++ b/html/xlsx-to-itad-odoo/record.html
@@ -54,7 +54,7 @@ class Record:
         one or more Record objects, or None
     &#34;&#34;&#34;
 
-    def __init__(self, **kwargs):
+    def __init__(self, **kwargs: dict) -&gt; None:
         self.serial = str(kwargs.get(&#39;serial&#39;))
         self.asset_tag = str(kwargs.get(&#39;asset_tag&#39;))
         self.make = str(kwargs.get(&#39;make&#39;))
@@ -71,13 +71,13 @@ class Record:
             # https://qrl.dell.com/H6FND42
             self.serial = self.serial.split(&#39;/&#39;)[-1]
 
-    def __str__(self):
+    def __str__(self) -&gt; str:
         &#34;&#34;&#34;
             Returns the serial number of this Record instance
         &#34;&#34;&#34;
         return self.serial
 
-    def __repr__(self):
+    def __repr__(self) -&gt; str:
         &#34;&#34;&#34;
             Used when iterating over a list of Record objects
 
@@ -110,7 +110,7 @@ class Record:
 <dl>
 <dt id="xlsx-to-itad-odoo.record.Record"><code class="flex name class">
 <span>class <span class="ident">Record</span></span>
-<span>(</span><span>**kwargs)</span>
+<span>(</span><span>**kwargs: dict)</span>
 </code></dt>
 <dd>
 <div class="desc"><p>Stores information about the line items to import.</p>
@@ -134,7 +134,7 @@ one or more Record objects, or None</p></div>
         one or more Record objects, or None
     &#34;&#34;&#34;
 
-    def __init__(self, **kwargs):
+    def __init__(self, **kwargs: dict) -&gt; None:
         self.serial = str(kwargs.get(&#39;serial&#39;))
         self.asset_tag = str(kwargs.get(&#39;asset_tag&#39;))
         self.make = str(kwargs.get(&#39;make&#39;))
@@ -151,13 +151,13 @@ one or more Record objects, or None</p></div>
             # https://qrl.dell.com/H6FND42
             self.serial = self.serial.split(&#39;/&#39;)[-1]
 
-    def __str__(self):
+    def __str__(self) -&gt; str:
         &#34;&#34;&#34;
             Returns the serial number of this Record instance
         &#34;&#34;&#34;
         return self.serial
 
-    def __repr__(self):
+    def __repr__(self) -&gt; str:
         &#34;&#34;&#34;
             Used when iterating over a list of Record objects
 

--- a/record.py
+++ b/record.py
@@ -23,7 +23,7 @@ class Record:
         one or more Record objects, or None
     """
 
-    def __init__(self, **kwargs):
+    def __init__(self, **kwargs: dict) -> None:
         self.serial = str(kwargs.get('serial'))
         self.asset_tag = str(kwargs.get('asset_tag'))
         self.make = str(kwargs.get('make'))
@@ -40,13 +40,13 @@ class Record:
             # https://qrl.dell.com/H6FND42
             self.serial = self.serial.split('/')[-1]
 
-    def __str__(self):
+    def __str__(self) -> str:
         """
             Returns the serial number of this Record instance
         """
         return self.serial
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         """
             Used when iterating over a list of Record objects
 


### PR DESCRIPTION
A configuration file has been added to pdoc to enable github links for blocks that are documented.
All of the methods now use [python type hints](https://www.python.org/dev/peps/pep-0484/)